### PR TITLE
feat: support multiple registration country codes

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -6,6 +6,7 @@ DB_USER=bikesharing
 DB_PASSWORD=password
 DB_DSN="mysql:host=${DB_HOST};dbname=${DB_DATABASE};charset=utf8"
 SMTP_FROM_EMAIL=email@example.com
+COUNTRY_CODES="[\"SK\"]"
 CREDIT_SYSTEM_ENABLED=true
 CREDIT_SYSTEM_CURRENCY=$
 CREDIT_SYSTEM_MIN_BALANCE=2

--- a/.env.dist
+++ b/.env.dist
@@ -77,8 +77,8 @@ CITIES="
         \"Bratislava\": [48.148154, 17.117232]
     }
 "
-#international dialing code (country code prefix), no plus sign
-COUNTRY_CODE=421
+#international dialing codes (country code prefixes), no plus sign
+COUNTRY_CODES="[\"SK\"]"
 SYSTEM_ZOOM=15
 SYSTEM_RULES=http://example.com/rules.htm
 #number of bikes user can rent after he registered: 0 = no bike, 1 = 1 bike etc.

--- a/.env.prod
+++ b/.env.prod
@@ -1,3 +1,4 @@
 APP_ENV=prod
 APP_DEBUG=0
 DB_DSN="mysql:host=${DB_HOST};dbname=${DB_DATABASE};charset=utf8"
+COUNTRY_CODES="[\"SK\"]"

--- a/.env.test
+++ b/.env.test
@@ -11,3 +11,4 @@ CITIES="
         \"Default City\": [48.148154, 17.117232]
     }
 "
+COUNTRY_CODES="[\"SK\"]"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
     "symfony/event-dispatcher": "^6.0",
     "symfony/form": "^6.0",
     "sentry/sentry-symfony": "^5.1",
-    "symfony/clock": "^6.4"
+    "symfony/clock": "^6.4",
+    "odolbeau/phone-number-bundle": "^4.2"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.10|^4.0",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -8,5 +8,6 @@ return [
     \Symfony\Bundle\TwigBundle\TwigBundle::class  => ['all' => true],
     \Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     \Sentry\SentryBundle\SentryBundle::class => ['all' => true],
+    \Misd\PhoneNumberBundle\MisdPhoneNumberBundle::class => ['all' => true],
     \Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle::class => ['test' => true],
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -103,7 +103,6 @@ return static function (ContainerConfigurator $container): void {
     $services->load('BikeShare\\SmsCommand\\', '../src/SmsCommand/*Command.php')
         ->bind(RentSystemInterface::class, expr('service("BikeShare\\\Rent\\\RentSystemFactory").getRentSystem("sms")'))
         ->bind('$forceStack', env('bool:FORCE_STACK'))
-        ->bind('$countryCode', env('COUNTRY_CODE'))
     ;
 
     $services->get(PdoDb::class)
@@ -136,7 +135,7 @@ return static function (ContainerConfigurator $container): void {
         );
 
     $services->get(PhonePurifier::class)
-        ->bind('$countryCode', env('COUNTRY_CODE'));
+        ->bind('$countryCodes', env('json:COUNTRY_CODES'));
 
     $services->get(CreditSystemFactory::class)
         ->bind('$isEnabled', env('bool:CREDIT_SYSTEM_ENABLED'));

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -160,7 +160,7 @@ class RegistrationFormType extends AbstractType
                     }
                 }
 
-                if (empty($data['number']) || strlen((string) $data['number']) < 5) {
+                if (empty($data['number']) || !$this->phonePurifier->isValid($data['number'])) {
                     $form->get('number')->addError(
                         new FormError(
                             $this->translator->trans('Invalid phone number.')

--- a/src/Purifier/PhonePurifierInterface.php
+++ b/src/Purifier/PhonePurifierInterface.php
@@ -4,5 +4,7 @@ namespace BikeShare\Purifier;
 
 interface PhonePurifierInterface
 {
-    public function purify(string $phoneNumber);
+    public function purify(string $phoneNumber): string;
+
+    public function isValid(string $phoneNumber): bool;
 }

--- a/src/SmsCommand/AddCommand.php
+++ b/src/SmsCommand/AddCommand.php
@@ -18,7 +18,6 @@ class AddCommand extends AbstractCommand implements SmsCommandInterface
 
     public function __construct(
         TranslatorInterface $translator,
-        private readonly string $countryCode,
         private readonly UserRegistration $userRegistration,
         private readonly UserRepository $userRepository,
         private readonly PhonePurifier $phonePurifier
@@ -29,11 +28,7 @@ class AddCommand extends AbstractCommand implements SmsCommandInterface
     public function __invoke(User $user, string $email, string $phone, string $fullName): string
     {
         $phone = $this->phonePurifier->purify($phone);
-
-        if (
-            $phone < $this->countryCode . "000000000"
-            || $phone > ((int)$this->countryCode + 1) . "000000000"
-        ) {
+        if (!$this->phonePurifier->isValid($phone)) {
             throw new ValidationException(
                 $this->translator->trans('Invalid phone number.')
             );

--- a/tests/Application/Controller/SmsRequestController/AddCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/AddCommandTest.php
@@ -25,7 +25,7 @@ class AddCommandTest extends BikeSharingWebTestCase
     {
         $adminPhoneNumber = self::ADMIN_PHONE_NUMBER;
         $email = 'testAddUser' . rand(1000, 9999) . '@net.net';
-        $phoneNumber = '42199999' . rand(1000, 9999);
+        $phoneNumber = '421903' . rand(100000, 999999);
         $fullName = 'Test User';
 
         $this->client->getContainer()->get('event_dispatcher')->addListener(

--- a/tests/Unit/Purifier/PhonePurifierTest.php
+++ b/tests/Unit/Purifier/PhonePurifierTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\Purifier;
 
 use BikeShare\Purifier\PhonePurifier;
+use libphonenumber\PhoneNumberUtil;
 use PHPUnit\Framework\TestCase;
 
 class PhonePurifierTest extends TestCase
@@ -17,42 +18,34 @@ class PhonePurifierTest extends TestCase
         $countryCode,
         $expectedPhoneNumber
     ) {
-        $purifier = new PhonePurifier($countryCode);
+        $purifier = new PhonePurifier(PhoneNumberUtil::getInstance(), [$countryCode]);
         $this->assertEquals($expectedPhoneNumber, $purifier->purify($phoneNumber));
     }
 
     public function purifyDataProvider()
     {
         yield 'default' => [
-            'phoneNumber' => '+1234567890',
-            'countryCode' => '123',
-            'expectedPhoneNumber' => '1234567890'
+            'phoneNumber' => '+421 903-123-456',
+            'countryCode' => 'SK',
+            'expectedPhoneNumber' => '421903123456'
         ];
-        yield 'restricted symbols remove' => [
-            'phoneNumber' => '+421 123-456-78/90.',
-            'countryCode' => '421',
-            'expectedPhoneNumber' => '4211234567890'
+        yield 'local number without prefix' => [
+            'phoneNumber' => '0903 123 456',
+            'countryCode' => 'SK',
+            'expectedPhoneNumber' => '421903123456'
         ];
-        yield 'letters symbols do not remove' => [
-            'phoneNumber' => '+421 123-456-78/90abcdefghijklmnopqrstuvwxyz',
-            'countryCode' => '421',
-            'expectedPhoneNumber' => '4211234567890'
+        yield 'international for another region' => [
+            'phoneNumber' => '+33123456789',
+            'countryCode' => 'SK',
+            'expectedPhoneNumber' => '33123456789'
         ];
-        yield 'without code' => [
-            'phoneNumber' => '0123-456-78/90',
-            'countryCode' => '421',
-            'expectedPhoneNumber' => '4211234567890'
-        ];
-        yield 'with 3 symbol code and with 0' => [
-            'phoneNumber' => '0421123-456-78/90',
-            'countryCode' => '421',
-            'expectedPhoneNumber' => '4211234567890'
-        ];
-        #is it correct??? maybe code can be less or more than 3 symbols???
-        yield 'with 2 symbol code and with 0' => [
-            'phoneNumber' => '0123-456-78/90',
-            'countryCode' => '12',
-            'expectedPhoneNumber' => '121234567890'
-        ];
+    }
+
+    public function testIsValid(): void
+    {
+        $purifier = new PhonePurifier(PhoneNumberUtil::getInstance(), ['SK', 'CZ']);
+        $this->assertTrue($purifier->isValid('421903123456'));
+        $this->assertTrue($purifier->isValid('420601123456'));
+        $this->assertFalse($purifier->isValid('33123456789'));
     }
 }


### PR DESCRIPTION
## Summary
- integrate odolbeau/phone-number-bundle and register bundle for phone parsing
- validate and normalize phone numbers through libphonenumber with allowed country codes from `COUNTRY_CODES`
- update tests and fixtures to use valid regional numbers

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68978c7be3bc83258cd0b7e83c1e01c3