### PR TITLE
Refactor rent system result into DTO and enum

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.1, 8.2]
+        php-version: [8.4, 8.5]
       fail-fast: false
 
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-apache
+FROM php:8.4-apache
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html/public
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }
   },
   "require": {
-    "php": "^8.1",
+    "php": "^8.4",
     "ext-curl": "*",
     "ext-gettext": "*",
     "ext-json": "*",
@@ -45,6 +45,7 @@
     "symfony/http-foundation": "^6.0",
     "symfony/http-kernel": "^6.0",
     "symfony/monolog-bundle": "^3.10",
+    "symfony/property-info": "^6.4",
     "symfony/runtime": "^6.0",
     "symfony/security-bundle": "^6.0",
     "symfony/translation": "^6.0",
@@ -54,11 +55,11 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.10|^4.0",
-    "phpunit/phpunit": "^9.6",
+    "phpunit/phpunit": "^12.5",
     "php-mock/php-mock-phpunit": "^2.13",
     "rector/rector": "^2.1",
     "symfony/browser-kit": "^6.0",
-    "symfony/test-pack": "^1.1",
+    "symfony/css-selector": "^6.0",
     "symfony/stopwatch": "^6.0",
     "nelmio/alice": "^3.9",
     "slevomat/coding-standard": "^8.19"

--- a/config/services.php
+++ b/config/services.php
@@ -74,6 +74,8 @@ return static function (ContainerConfigurator $container): void {
             '../src/Event',
             '../src/Command/LoadFixturesCommand.php',
             '../src/SmsCommand/*Command.php',
+            '../src/Rent/DTO',
+            '../src/Rent/Enum',
         ]);
 
     $services->get(\BikeShare\App\Security\ApiTokenAuthenticator::class)
@@ -111,7 +113,10 @@ return static function (ContainerConfigurator $container): void {
         ->bind('$commandLocator', tagged_locator('smsCommand', null, 'getName'));
 
     $services->load('BikeShare\\SmsCommand\\', '../src/SmsCommand/*Command.php')
-        ->bind(RentSystemInterface::class, expr('service("BikeShare\\\Rent\\\RentSystemFactory").getRentSystem("sms")'))
+        ->bind(
+            RentSystemInterface::class,
+            expr('service("BikeShare\\\Rent\\\RentSystemFactory").getRentSystem(constant("BikeShare\\\\Rent\\\\Enum\\\\RentSystemType::SMS"))')
+        )
         ->bind('$forceStack', env('bool:FORCE_STACK'))
     ;
 
@@ -164,6 +169,10 @@ return static function (ContainerConfigurator $container): void {
         ->bind('$violationFee', env('float:CREDIT_SYSTEM_VIOLATION_FEE'));
 
     $services->load('BikeShare\\Rent\\', '../src/Rent')
+        ->exclude([
+            '../src/Rent/DTO',
+            '../src/Rent/Enum',
+        ])
         ->bind(
             '$watchesConfig',
             [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,19 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          cacheResult="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         stopOnWarning="true"
-         stopOnFailure="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage includeUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+         failOnWarning="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnPhpunitNotices="true"
+         failOnPhpunitDeprecation="true"
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="BikeShare Test Suite">
             <directory>./tests/</directory>
@@ -21,11 +16,14 @@
     </testsuites>
     <php>
         <env name="KERNEL_CLASS" value="\BikeShare\App\Kernel"/>
-        <ini name="display_errors" value="1" />
-        <ini name="error_reporting" value="-1" />
-        <server name="APP_ENV" value="test" force="true" />
-        <server name="SHELL_VERBOSITY" value="-1" />
-        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="9.6" />
+        <ini name="display_errors" value="1"/>
+        <ini name="error_reporting" value="-1"/>
+        <server name="APP_ENV" value="test" force="true"/>
+        <server name="SHELL_VERBOSITY" value="-1"/>
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Set\ValueObject\SetList;
+use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -10,15 +13,23 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
-    ->withPhpVersion(\Rector\ValueObject\PhpVersion::PHP_81)
+    ->withPhpVersion(PhpVersion::PHP_84)
     ->withSets([
-        \Rector\Set\ValueObject\SetList::PHP_81,
-        \Rector\Set\ValueObject\SetList::CODE_QUALITY,
-        \Rector\Set\ValueObject\SetList::CODING_STYLE,
-        \Rector\Set\ValueObject\SetList::PHP_POLYFILLS,
-    ])->withComposerBased(
+        SetList::PHP_84,
+        PHPUnitSetList::PHPUNIT_120,
+        SetList::CODE_QUALITY,
+        SetList::CODING_STYLE,
+        SetList::PHP_POLYFILLS,
+    ])
+    ->withComposerBased(
         twig: true,
         symfony: true,
-        phpunit: true,
+        phpunit: false,
     )
-    ;
+    ->withImportNames(
+        importNames: true,
+        importDocBlockNames: true,
+        importShortClasses: false,
+        removeUnusedImports: true,
+    )
+;

--- a/src/App/DependencyInjection/CreditSystemCompilerPass.php
+++ b/src/App/DependencyInjection/CreditSystemCompilerPass.php
@@ -28,6 +28,7 @@ class CreditSystemCompilerPass implements CompilerPassInterface
 
         $creditSystem = new Definition(CreditSystemInterface::class);
         $creditSystem->setFactory([$factory, 'getCreditSystem']);
+
         $container->setDefinition(CreditSystemInterface::class, $creditSystem);
     }
 }

--- a/src/App/DependencyInjection/MailSenderCompilerPass.php
+++ b/src/App/DependencyInjection/MailSenderCompilerPass.php
@@ -28,6 +28,7 @@ class MailSenderCompilerPass implements CompilerPassInterface
 
         $mailSender = new Definition(MailSenderInterface::class);
         $mailSender->setFactory([$factory, 'getMailSender']);
+
         $container->setDefinition(MailSenderInterface::class, $mailSender);
     }
 }

--- a/src/App/DependencyInjection/RentSystemCompilerPass.php
+++ b/src/App/DependencyInjection/RentSystemCompilerPass.php
@@ -19,7 +19,7 @@ class RentSystemCompilerPass implements CompilerPassInterface
 
         $rentSystems = [];
         foreach (array_keys($rentSystemServiceIds) as $id) {
-            $rentSystems[$id::getType()] = new Reference($id);
+            $rentSystems[$id::getType()->value] = new Reference($id);
         }
 
         $factory->setArgument('$locator', ServiceLocatorTagPass::register($container, $rentSystems, 'rentSystems'));

--- a/src/App/DependencyInjection/SmsConnectorCompilerPass.php
+++ b/src/App/DependencyInjection/SmsConnectorCompilerPass.php
@@ -28,6 +28,7 @@ class SmsConnectorCompilerPass implements CompilerPassInterface
 
         $smsConnector = new Definition(SmsConnectorInterface::class);
         $smsConnector->setFactory([$factory, 'getConnector']);
+
         $container->setDefinition(SmsConnectorInterface::class, $smsConnector);
     }
 }

--- a/src/App/Kernel.php
+++ b/src/App/Kernel.php
@@ -12,21 +12,11 @@ use BikeShare\App\DependencyInjection\SmsConnectorCompilerPass;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
-
-    public function boot(): void
-    {
-        if ($this->debug) {
-            Debug::enable();
-        }
-
-        parent::boot();
-    }
 
     protected function configureContainer(ContainerConfigurator $container): void
     {

--- a/src/App/Security/ApiTokenAuthenticator.php
+++ b/src/App/Security/ApiTokenAuthenticator.php
@@ -63,7 +63,7 @@ class ApiTokenAuthenticator extends AbstractAuthenticator implements Authenticat
         return new JsonResponse(['error' => 'Unauthorized', 'message' => 'Invalid credentials'], 401);
     }
 
-    public function start(Request $request, AuthenticationException $authException = null): JsonResponse
+    public function start(Request $request, ?AuthenticationException $authException = null): JsonResponse
     {
         $response = new JsonResponse(['error' => 'Unauthorized', 'message' => 'Authentication required'], 401);
         $response->headers->set('WWW-Authenticate', 'Bearer');

--- a/src/Command/InactiveStandBikesCheckCommand.php
+++ b/src/Command/InactiveStandBikesCheckCommand.php
@@ -6,8 +6,6 @@ namespace BikeShare\Command;
 
 use BikeShare\Notifier\AdminNotifier;
 use BikeShare\Repository\BikeRepository;
-use DateInterval;
-use DateTimeImmutable;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -32,7 +30,7 @@ class InactiveStandBikesCheckCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $now = $this->clock->now();
-        $weekThreshold = $now->sub(new DateInterval('P7D'));
+        $weekThreshold = $now->sub(new \DateInterval('P7D'));
         $isSilent = $output->isQuiet();
         $io = new SymfonyStyle($input, $output);
 
@@ -49,7 +47,7 @@ class InactiveStandBikesCheckCommand extends Command
         $lines = [];
         $rows = [];
         foreach ($inactiveBikes as $bike) {
-            $lastMoveTime = new DateTimeImmutable((string)$bike['lastMoveTime']);
+            $lastMoveTime = new \DateTimeImmutable((string)$bike['lastMoveTime']);
             $inactiveDays = (int)$lastMoveTime->diff($now)->days;
             $bikeNumber = (int)$bike['bikeNum'];
             $standName = (string)$bike['standName'];
@@ -103,6 +101,7 @@ class InactiveStandBikesCheckCommand extends Command
         foreach ($bikeLines as $bikeLine) {
             $lines[] = '- ' . $bikeLine;
         }
+
         if ([] === $bikeLines) {
             $lines[] = '- none';
         }

--- a/src/Command/MigrateCreditHistoryCommand.php
+++ b/src/Command/MigrateCreditHistoryCommand.php
@@ -91,7 +91,7 @@ class MigrateCreditHistoryCommand extends Command
                 }
             } catch (\Exception $e) {
                 $totalErrors++;
-                $io->warning("Error migrating user {$userId}: {$e->getMessage()}");
+                $io->warning(sprintf('Error migrating user %d: %s', $userId, $e->getMessage()));
             }
 
             $io->progressAdvance();
@@ -209,6 +209,7 @@ class MigrateCreditHistoryCommand extends Command
                         ['id' => $record['id']]
                     );
                 }
+
                 $deleted++;
                 continue;
             }
@@ -224,6 +225,7 @@ class MigrateCreditHistoryCommand extends Command
                     // Reverse the transaction to get previous balance
                     $runningBalance -= $amount;
                 }
+
                 continue;
             }
 
@@ -237,6 +239,7 @@ class MigrateCreditHistoryCommand extends Command
                         ['id' => $record['id']]
                     );
                 }
+
                 $deleted++;
                 continue;
             }
@@ -372,7 +375,7 @@ class MigrateCreditHistoryCommand extends Command
         }
 
         // Fallback if nothing parsed
-        if (empty($newRecords) && abs($totalAmount) >= 0.001) {
+        if ($newRecords === [] && abs($totalAmount) >= 0.001) {
             $newRecords[] = [
                 'amount' => $totalAmount,
                 'balance' => 0.0,

--- a/src/Command/PasswordHashStatsCommand.php
+++ b/src/Command/PasswordHashStatsCommand.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Throwable;
 
 #[AsCommand(name: 'app:password_hash_stats', description: 'Show password hash migration statistics')]
 class PasswordHashStatsCommand extends Command

--- a/src/Controller/Api/BikeController.php
+++ b/src/Controller/Api/BikeController.php
@@ -6,6 +6,7 @@ namespace BikeShare\Controller\Api;
 
 use BikeShare\Db\DbInterface;
 use BikeShare\Enum\Action;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\HistoryRepository;
@@ -83,7 +84,7 @@ class BikeController extends AbstractController
             return $this->json([], Response::HTTP_BAD_REQUEST);
         }
 
-        $response = $rentSystemFactory->getRentSystem('web')->rentBike(
+        $response = $rentSystemFactory->getRentSystem(RentSystemType::WEB)->rentBike(
             $this->getUser()->getUserId(),
             (int)$bikeNumber
         );
@@ -109,7 +110,7 @@ class BikeController extends AbstractController
             return $this->json([], Response::HTTP_BAD_REQUEST);
         }
 
-        $response = $rentSystemFactory->getRentSystem('web')->returnBike(
+        $response = $rentSystemFactory->getRentSystem(RentSystemType::WEB)->returnBike(
             $this->getUser()->getUserId(),
             (int)$bikeNumber,
             $standName,
@@ -135,7 +136,7 @@ class BikeController extends AbstractController
             return $this->json([], Response::HTTP_BAD_REQUEST);
         }
 
-        $response = $rentSystemFactory->getRentSystem('web')->rentBike(
+        $response = $rentSystemFactory->getRentSystem(RentSystemType::WEB)->rentBike(
             $this->getUser()->getUserId(),
             (int)$bikeNumber,
             true // Force rent
@@ -162,7 +163,7 @@ class BikeController extends AbstractController
             return $this->json([], Response::HTTP_BAD_REQUEST);
         }
 
-        $response = $rentSystemFactory->getRentSystem('web')->returnBike(
+        $response = $rentSystemFactory->getRentSystem(RentSystemType::WEB)->returnBike(
             $this->getUser()->getUserId(),
             (int)$bikeNumber,
             $standName,
@@ -236,7 +237,7 @@ class BikeController extends AbstractController
             return $this->json([], Response::HTTP_BAD_REQUEST);
         }
 
-        $response = $rentSystemFactory->getRentSystem('web')->revertBike(
+        $response = $rentSystemFactory->getRentSystem(RentSystemType::WEB)->revertBike(
             $this->getUser()->getUserId(),
             (int)$bikeNumber,
         );

--- a/src/Controller/Api/StandController.php
+++ b/src/Controller/Api/StandController.php
@@ -61,6 +61,7 @@ class StandController extends AbstractController
             );
             $bike['notes'] = implode('; ', $notes);
         }
+
         unset($bike);
 
         return $this->json(

--- a/src/Controller/LanguageController.php
+++ b/src/Controller/LanguageController.php
@@ -41,7 +41,7 @@ class LanguageController extends AbstractController
         }
 
         $referer = $request->headers->get('referer');
-        if ($referer && strpos($referer, '/switchLanguage') === false) {
+        if ($referer && !str_contains($referer, '/switchLanguage')) {
             return $this->redirect($referer);
         }
 

--- a/src/Controller/RegisterController.php
+++ b/src/Controller/RegisterController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Controller;
 
+use Symfony\Component\Security\Core\User\UserInterface;
 use BikeShare\Form\RegistrationFormType;
 use BikeShare\Purifier\PhonePurifierInterface;
 use BikeShare\User\UserRegistration;
@@ -23,7 +24,7 @@ class RegisterController extends AbstractController
         UserRegistration $userRegistration,
         PhonePurifierInterface $phonePurifier,
     ): Response {
-        if ($this->getUser()) {
+        if ($this->getUser() instanceof UserInterface) {
             return $this->redirectToRoute('home');
         }
 

--- a/src/Controller/ScanController.php
+++ b/src/Controller/ScanController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Controller;
 
 use BikeShare\Db\DbInterface;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -44,15 +45,15 @@ class ScanController extends AbstractController
             && $request->request->has('rent')
             && $request->request->get('rent') === "yes"
         ) {
-            $rentSystem = $this->rentSystemFactory->getRentSystem('qr');
+            $rentSystem = $this->rentSystemFactory->getRentSystem(RentSystemType::QR);
             $result = $rentSystem->rentBike($this->getUser()->getUserId(), $bikeNumber);
-            if ($result['error']) {
-                $error = $result['message'];
+            if ($result->isError()) {
+                $error = $result->getMessage();
             } else {
-                $message = $result['message'];
+                $message = $result->getMessage();
             }
 
-            $this->logResponse($result['message']);
+            $this->logResponse($result->getMessage());
         }
 
         return $this->render('scan/rent.html.twig', [
@@ -73,15 +74,15 @@ class ScanController extends AbstractController
         if (empty($stand)) {
             $error = $this->translator->trans('Stand {standName} does not exist.', ['standName' => $standName]);
         } else {
-            $rentSystem = $this->rentSystemFactory->getRentSystem('qr');
+            $rentSystem = $this->rentSystemFactory->getRentSystem(RentSystemType::QR);
             $result = $rentSystem->returnBike($this->getUser()->getUserId(), 0, $standName);
-            if ($result['error']) {
-                $error = $result['message'];
+            if ($result->isError()) {
+                $error = $result->getMessage();
             } else {
-                $message = $result['message'];
+                $message = $result->getMessage();
             }
 
-            $this->logResponse($result['message']);
+            $this->logResponse($result->getMessage());
         }
 
         return $this->render('scan/return.html.twig', [

--- a/src/Controller/SmsRequestController.php
+++ b/src/Controller/SmsRequestController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace BikeShare\Controller;
 
-use BikeShare\App\Entity\User;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Notifier\AdminNotifier;
 use BikeShare\Purifier\PhonePurifierInterface;

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -44,7 +44,7 @@ class UserController extends AbstractController
 
         return $this->render('user/profile.html.twig', [
             'user' => $user,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 }

--- a/src/Credit/CreditSystem.php
+++ b/src/Credit/CreditSystem.php
@@ -8,27 +8,33 @@ use BikeShare\Db\DbInterface;
 use BikeShare\Enum\Action;
 use BikeShare\Enum\CreditChangeType;
 use BikeShare\Repository\HistoryRepository;
-use DateTimeImmutable;
 
 class CreditSystem implements CreditSystemInterface
 {
     // false = no credit system and Exceptions will be thrown
     // true = apply credit system rules and deductions
     private readonly bool $isEnabled;
+
     // currency used for credit system
     private readonly string $creditCurrency;
+
     // minimum credit required to allow any bike operations
     private readonly float $minBalanceCredit;
+
     // rental fee (after WATCHES_FREE_TIME)
     private readonly float $rentalFee;
+
     // 0 = disabled,
     // 1 = charge flat price CREDIT_SYSTEM_RENTAL_FEE every WATCHES_FLAT_PRICE_CYCLE minutes,
     // 2 = charge doubled price CREDIT_SYSTEM_RENTAL_FEE every WATCHES_DOUBLE_PRICE_CYCLE minutes
     private readonly int $priceCycle;
+
     // long rental fee (WATCHES_LONG_RENTAL time)
     private readonly float $longRentalFee;
+
     // credit needed to temporarily increase limit, applicable only when USER_BIKE_LIMIT_INCREASE > 0
     private readonly float $limitIncreaseFee;
+
     // credit deduction for rule violations (applied by admins)
     private readonly float $violationFee;
 
@@ -99,7 +105,7 @@ class CreditSystem implements CreditSystemInterface
             'amount' => $amount,
             'balance' => $newBalance,
             'reason' => $type->value,
-            ...(!empty($context['couponCode']) ? ['couponCode' => $context['couponCode']] : []),
+            ...(empty($context['couponCode']) ? [] : ['couponCode' => $context['couponCode']]),
         ], JSON_THROW_ON_ERROR);
 
         $this->historyRepository->addItem(
@@ -134,7 +140,7 @@ class CreditSystem implements CreditSystemInterface
             'amount' => -$amount,
             'balance' => $newBalance,
             'reason' => $type->value,
-            ...(!empty($context['couponCode']) ? ['couponCode' => $context['couponCode']] : []),
+            ...(empty($context['couponCode']) ? [] : ['couponCode' => $context['couponCode']]),
         ], JSON_THROW_ON_ERROR);
 
         $this->historyRepository->addItem(
@@ -209,7 +215,7 @@ class CreditSystem implements CreditSystemInterface
         $parsed = [];
 
         foreach ($history as $entry) {
-            $date = new DateTimeImmutable($entry['time']);
+            $date = new \DateTimeImmutable($entry['time']);
             $parameter = $entry['parameter'];
 
             $jsonData = json_decode($parameter, true, JSON_THROW_ON_ERROR);

--- a/src/Db/PdoDbResult.php
+++ b/src/Db/PdoDbResult.php
@@ -44,8 +44,8 @@ class PdoDbResult implements DbResultInterface
     /**
      * @phpcs:disable Generic.NamingConventions.CamelCapsFunctionName
      * @phpcs:disable PSR1.Methods.CamelCapsMethodName
-     * @deprecated use fetchAssoc
      */
+    #[\Deprecated(message: 'use fetchAssoc')]
     public function fetch_assoc()
     {
         return $this->fetchAssoc();

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -22,6 +22,7 @@ class LocaleListener
         $locale = $request->getPreferredLanguage($this->enabledLocales) ?? $this->defaultLocale;
 
         $locale = $session->get('_locale', $locale);
+
         $request->setLocale($locale);
     }
 }

--- a/src/EventListener/LoginSuccessEventListener.php
+++ b/src/EventListener/LoginSuccessEventListener.php
@@ -17,7 +17,7 @@ class LoginSuccessEventListener
 
     public function __invoke(LoginSuccessEvent $event): void
     {
-        if (!is_a($event->getUser(), User::class)) {
+        if (!$event->getUser() instanceof User) {
             return;
         }
 

--- a/src/EventListener/SmsControllerEventListener.php
+++ b/src/EventListener/SmsControllerEventListener.php
@@ -47,10 +47,10 @@ class SmsControllerEventListener
         $sms_text = $this->smsConnector->getMessage();
         $ip = $this->smsConnector->getIPAddress();
 
-        $result = $this->db->query('SELECT sms_uuid FROM received WHERE sms_uuid=:sms_uuid', compact('sms_uuid'));
+        $result = $this->db->query('SELECT sms_uuid FROM received WHERE sms_uuid=:sms_uuid', ['sms_uuid' => $sms_uuid]);
         if ($result->rowCount() >= 1) {
             // sms already exists in DB, possible problem
-            $this->logger->error("SMS already exists in DB", compact('sms_uuid'));
+            $this->logger->error("SMS already exists in DB", ['sms_uuid' => $sms_uuid]);
             $this->adminNotifier->notify(
                 $this->translator->trans('Problem with SMS') . $sms_uuid,
                 false

--- a/src/Purifier/PhonePurifier.php
+++ b/src/Purifier/PhonePurifier.php
@@ -25,7 +25,7 @@ class PhonePurifier implements PhonePurifierInterface
         $phoneNumber = trim($phoneNumber);
 
         $parsed = $this->parse($phoneNumber);
-        if ($parsed !== null) {
+        if ($parsed instanceof PhoneNumber) {
             return ltrim(
                 $this->phoneNumberUtil->format($parsed, PhoneNumberFormat::E164),
                 '+'
@@ -37,7 +37,7 @@ class PhonePurifier implements PhonePurifierInterface
 
     public function isValid(string $phoneNumber): bool
     {
-        return $this->parse($phoneNumber) !== null;
+        return $this->parse($phoneNumber) instanceof PhoneNumber;
     }
 
     private function parse(string $phoneNumber): ?PhoneNumber

--- a/src/Rent/AbstractRentSystem.php
+++ b/src/Rent/AbstractRentSystem.php
@@ -207,6 +207,7 @@ abstract class AbstractRentSystem implements RentSystemInterface
 //                ['bikeNumber' => $bikeNum]
 //            );
         }
+
         $result = $this->db->query(
             "INSERT INTO history SET userId = :userId, bikeNum = :bikeNum, action = :action, parameter = :newCode, time = :time",
             [
@@ -235,7 +236,7 @@ abstract class AbstractRentSystem implements RentSystemInterface
         if (!$result->rowCount()) {
             return $this->response(
                 $this->translator->trans(
-                    'Stand name \'{standName}\' does not exist. Stands are marked by CAPITALLETTERS.',
+                    "Stand name '{standName}' does not exist. Stands are marked by CAPITALLETTERS.",
                     ['standName' => $stand]
                 ),
                 self::ERROR,
@@ -311,6 +312,7 @@ abstract class AbstractRentSystem implements RentSystemInterface
                 $params['creditCurrency'] = $this->creditSystem->getCreditCurrency();
             }
         }
+
         $result = $this->db->query(
             "INSERT INTO history SET userId = :userId, bikeNum = :bikeNum, action = :action, parameter = :standId, time = :time",
             [
@@ -398,7 +400,7 @@ abstract class AbstractRentSystem implements RentSystemInterface
                     'userId' => $userId,
                     'bikeNum' => $bikeId,
                     'action' => Action::REVERT->value,
-                    'parameter' => "$standId|$code",
+                    'parameter' => sprintf('%s|%s', $standId, $code),
                     'time' => $this->clock->now()->format('Y-m-d H:i:s'),
                 ]
             );
@@ -488,6 +490,7 @@ abstract class AbstractRentSystem implements RentSystemInterface
         } else {
             $bikeStatus = $this->translator->trans('used by {userName} +{phone}', ['userName' => $userName, 'phone' => $phone]);
         }
+
         $this->db->query(
             'INSERT INTO notes (bikeNum, userId, note) VALUES (:bikeNum, :userId, :note)',
             [

--- a/src/Rent/DTO/RentSystemResult.php
+++ b/src/Rent/DTO/RentSystemResult.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Rent\DTO;
+
+use BikeShare\Rent\Enum\RentSystemType;
+
+class RentSystemResult implements \JsonSerializable
+{
+    public function __construct(
+        private readonly bool $error,
+        private readonly string $message,
+        private readonly string $code,
+        private readonly array $params = [],
+        private readonly RentSystemType $systemType,
+    ) {
+        if (trim($this->message) === '') {
+            throw new \InvalidArgumentException('message cannot be empty.');
+        }
+
+        if (trim($this->code) === '') {
+            throw new \InvalidArgumentException('code cannot be empty.');
+        }
+    }
+
+    public function isError(): bool
+    {
+        return $this->error;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getParams(): array
+    {
+        return $this->params;
+    }
+
+    public function getSystemType(): RentSystemType
+    {
+        return $this->systemType;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'error' => $this->error,
+            'message' => $this->message,
+            'code' => $this->code,
+            'params' => $this->params,
+            'systemType' => $this->systemType->value,
+        ];
+    }
+}

--- a/src/Rent/Enum/RentSystemType.php
+++ b/src/Rent/Enum/RentSystemType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Rent\Enum;
+
+enum RentSystemType: string
+{
+    case WEB = 'web';
+    case SMS = 'sms';
+    case QR = 'qr';
+}

--- a/src/Rent/RentSystemFactory.php
+++ b/src/Rent/RentSystemFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Rent;
 
+use BikeShare\Rent\Enum\RentSystemType;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class RentSystemFactory
@@ -13,10 +14,10 @@ class RentSystemFactory
     ) {
     }
 
-    public function getRentSystem(string $type): RentSystemInterface
+    public function getRentSystem(RentSystemType $type): RentSystemInterface
     {
-        if ($this->locator->has($type)) {
-            return $this->locator->get($type);
+        if ($this->locator->has($type->value)) {
+            return $this->locator->get($type->value);
         }
 
         throw new \InvalidArgumentException('Invalid rent system type');

--- a/src/Rent/RentSystemInterface.php
+++ b/src/Rent/RentSystemInterface.php
@@ -2,13 +2,16 @@
 
 namespace BikeShare\Rent;
 
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
+
 interface RentSystemInterface
 {
-    public function rentBike($userId, $bikeId, $force = false);
+    public function rentBike($userId, $bikeId, $force = false): RentSystemResult;
 
-    public function returnBike($userId, $bikeId, $standName, $note = '', $force = false);
+    public function returnBike($userId, $bikeId, $standName, $note = '', $force = false): RentSystemResult;
 
-    public function revertBike($userId, $bikeId);
+    public function revertBike($userId, $bikeId): RentSystemResult;
 
-    public static function getType(): string;
+    public static function getType(): RentSystemType;
 }

--- a/src/Rent/RentSystemQR.php
+++ b/src/Rent/RentSystemQR.php
@@ -2,19 +2,22 @@
 
 namespace BikeShare\Rent;
 
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
+
 /**
  * @phpcs:disable Generic.Files.LineLength
  */
 class RentSystemQR extends AbstractRentSystem implements RentSystemInterface
 {
-    public function rentBike($userId, $bikeId, $force = false)
+    public function rentBike($userId, $bikeId, $force = false): RentSystemResult
     {
         $force = false; #rent by qr code cannot be forced
 
         return parent::rentBike($userId, $bikeId, $force);
     }
 
-    public function returnBike($userId, $bikeId, $standName, $note = '', $force = false)
+    public function returnBike($userId, $bikeId, $standName, $note = '', $force = false): RentSystemResult
     {
         $force = false; #return by qr code cannot be forced
         $note = ''; #note cannot be provided via qr code
@@ -22,9 +25,8 @@ class RentSystemQR extends AbstractRentSystem implements RentSystemInterface
         if ($bikeId !== 0) {
             $this->logger->error("Bike number could not be provided via QR code", ["userId" => $userId]);
 
-            return $this->response(
+            return $this->error(
                 $this->translator->trans('Invalid bike number'),
-                self::ERROR,
                 'bike.return.error.invalid_bike_number'
             );
         }
@@ -33,9 +35,8 @@ class RentSystemQR extends AbstractRentSystem implements RentSystemInterface
         $bikeNumber = $result->rowCount();
 
         if ($bikeNumber === 0) {
-            return $this->response(
+            return $this->error(
                 $this->translator->trans('You currently have no rented bikes.'),
-                self::ERROR,
                 'bike.return.error.no_rented_bikes'
             );
         } elseif ($bikeNumber > 1) {
@@ -50,9 +51,8 @@ class RentSystemQR extends AbstractRentSystem implements RentSystemInterface
                 );
             }
 
-            return $this->response(
+            return $this->error(
                 $message,
-                self::ERROR,
                 'bike.return.error.multiple_rented_bikes',
                 ['bikeNumber' => $bikeNumber],
             );
@@ -63,17 +63,16 @@ class RentSystemQR extends AbstractRentSystem implements RentSystemInterface
         return parent::returnBike($userId, $bikeId, $standName, $note, $force);
     }
 
-    public function revertBike($userId, $bikeId)
+    public function revertBike($userId, $bikeId): RentSystemResult
     {
-        return $this->response(
+        return $this->error(
             $this->translator->trans('Revert is not supported for QR code'),
-            self::ERROR,
             'bike.revert.error.not_supported'
         );
     }
 
-    public static function getType(): string
+    public static function getType(): RentSystemType
     {
-        return 'qr';
+        return RentSystemType::QR;
     }
 }

--- a/src/Rent/RentSystemSms.php
+++ b/src/Rent/RentSystemSms.php
@@ -4,20 +4,17 @@ declare(strict_types=1);
 
 namespace BikeShare\Rent;
 
+use BikeShare\Rent\Enum\RentSystemType;
+
 class RentSystemSms extends AbstractRentSystem implements RentSystemInterface
 {
-    public static function getType(): string
+    public static function getType(): RentSystemType
     {
-        return 'sms';
+        return RentSystemType::SMS;
     }
 
-    protected function response($message, $error = 0, string $code = '', array $params = []): array
+    protected function normalizeMessage(string $message): string
     {
-        return [
-            'error' => $error,
-            'message' => strip_tags($message),
-            'code' => $code,
-            'params' => $params,
-        ];
+        return strip_tags($message);
     }
 }

--- a/src/Rent/RentSystemWeb.php
+++ b/src/Rent/RentSystemWeb.php
@@ -2,10 +2,12 @@
 
 namespace BikeShare\Rent;
 
+use BikeShare\Rent\Enum\RentSystemType;
+
 class RentSystemWeb extends AbstractRentSystem implements RentSystemInterface
 {
-    public static function getType(): string
+    public static function getType(): RentSystemType
     {
-        return 'web';
+        return RentSystemType::WEB;
     }
 }

--- a/src/Repository/UserSettingsRepository.php
+++ b/src/Repository/UserSettingsRepository.php
@@ -43,6 +43,7 @@ class UserSettingsRepository
                 ['userId' => $userId, 'settings' => $row['settings'], 'exception' => $e]
             );
         }
+
         $settings = array_merge($this->defaultSettings, $settings);
 
         return $settings;

--- a/src/SmsCommand/AddCommand.php
+++ b/src/SmsCommand/AddCommand.php
@@ -32,6 +32,7 @@ class AddCommand extends AbstractCommand implements SmsCommandInterface
                 $this->translator->trans('Invalid phone number.')
             );
         }
+
         $phone = $this->phonePurifier->purify($phone);
 
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {

--- a/src/SmsCommand/DelNoteCommand.php
+++ b/src/SmsCommand/DelNoteCommand.php
@@ -62,7 +62,7 @@ class DelNoteCommand extends AbstractCommand implements SmsCommandInterface
             $pattern
         );
 
-        if ($count == 0) {
+        if ($count === 0) {
             if (is_null($pattern)) {
                 throw new ValidationException(
                     $this->translator->trans(

--- a/src/SmsCommand/ForceRentCommand.php
+++ b/src/SmsCommand/ForceRentCommand.php
@@ -24,7 +24,7 @@ class ForceRentCommand extends AbstractCommand implements SmsCommandInterface
     {
         $response = $this->rentSystem->rentBike($user->getUserId(), $bikeNumber, true);
 
-        return $response['message'];
+        return $response->getMessage();
     }
 
     public function getHelpMessage(): string

--- a/src/SmsCommand/ForceReturnCommand.php
+++ b/src/SmsCommand/ForceReturnCommand.php
@@ -24,7 +24,7 @@ class ForceReturnCommand extends AbstractCommand implements SmsCommandInterface
     {
         $response = $this->rentSystem->returnBike($user->getUserId(), $bikeNumber, $standName, $note, true);
 
-        return $response['message'];
+        return $response->getMessage();
     }
 
     public function getHelpMessage(): string

--- a/src/SmsCommand/LastCommand.php
+++ b/src/SmsCommand/LastCommand.php
@@ -34,7 +34,7 @@ class LastCommand extends AbstractCommand implements SmsCommandInterface
         $lastUsage = $this->bikeRepository->findItemLastUsage($bikeNumber);
 
         $historyInfo = [];
-        $historyInfo[] = "B.$bikeNumber:";
+        $historyInfo[] = sprintf('B.%d:', $bikeNumber);
         foreach ($lastUsage['history'] as $row) {
             if (!in_array($row['action'], [Action::RETURN->value, Action::RENT->value, Action::REVERT->value])) {
                 continue;

--- a/src/SmsCommand/RentCommand.php
+++ b/src/SmsCommand/RentCommand.php
@@ -23,7 +23,7 @@ class RentCommand extends AbstractCommand implements SmsCommandInterface
     {
         $response = $this->rentSystem->rentBike($user->getUserId(), $bikeNumber);
 
-        return $response['message'];
+        return $response->getMessage();
     }
 
     public function getHelpMessage(): string

--- a/src/SmsCommand/ReturnCommand.php
+++ b/src/SmsCommand/ReturnCommand.php
@@ -23,7 +23,7 @@ class ReturnCommand extends AbstractCommand implements SmsCommandInterface
     {
         $response = $this->rentSystem->returnBike($user->getUserId(), $bikeNumber, $standName, $note);
 
-        return $response['message'];
+        return $response->getMessage();
     }
 
     public function getHelpMessage(): string

--- a/src/SmsCommand/RevertCommand.php
+++ b/src/SmsCommand/RevertCommand.php
@@ -24,7 +24,7 @@ class RevertCommand extends AbstractCommand implements SmsCommandInterface
     {
         $response = $this->rentSystem->revertBike($user->getUserId(), $bikeNumber);
 
-        return $response['message'];
+        return $response->getMessage();
     }
 
     public function getHelpMessage(): string

--- a/src/SmsConnector/EuroSmsConnector.php
+++ b/src/SmsConnector/EuroSmsConnector.php
@@ -72,7 +72,7 @@ class EuroSmsConnector extends AbstractConnector
 
         if ($statusCode < 200 || $statusCode >= 300) {
             // Potentially log error response content: $response->getContent(false)
-            throw new \RuntimeException("Failed to send SMS. API responded with status code: {$statusCode}");
+            throw new \RuntimeException('Failed to send SMS. API responded with status code: ' . $statusCode);
         }
     }
 

--- a/tests/Application/BikeSharingWebTestCase.php
+++ b/tests/Application/BikeSharingWebTestCase.php
@@ -30,6 +30,7 @@ abstract class BikeSharingWebTestCase extends WebTestCase
         // grab & reset the monolog TestHandler
         $handler = $this->client->getContainer()->get('monolog.handler.test');
         $handler->clear();
+
         $this->expected = [];
     }
 
@@ -94,14 +95,7 @@ abstract class BikeSharingWebTestCase extends WebTestCase
                 // only care about ERROR and above
                 continue;
             }
-
-            $isExpected = false;
-            foreach ($this->expected as $expected) {
-                if ($matches($record, $expected)) {
-                    $isExpected = true;
-                    break;
-                }
-            }
+            $isExpected = array_any($this->expected, fn($expected) => $matches($record, $expected));
 
             if (!$isExpected) {
                 $unexpected[] = $record;

--- a/tests/Application/Controller/Api/Bike/BikeForceRentReturnTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeForceRentReturnTest.php
@@ -60,7 +60,7 @@ class BikeForceRentReturnTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . json_encode($response));
+        $this->assertFalse($response['error'], 'Response with error: ' . json_encode($response));
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('currentCode', $response['params'], 'Response params does not contain currentCode');
         $this->assertArrayHasKey('newCode', $response['params'], 'Response params does not contain newCode');
@@ -140,7 +140,7 @@ class BikeForceRentReturnTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . $response['message']);
+        $this->assertFalse($response['error'], 'Response with error: ' . $response['message']);
         $this->assertSame($response['code'], 'bike.return.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('standName', $response['params'], 'Response params does not contain standName');

--- a/tests/Application/Controller/Api/Bike/BikeLastUsageTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeLastUsageTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\Api\Bike;
 
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Enum\Action;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +22,7 @@ class BikeLastUsageTest extends BikeSharingWebTestCase
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
         $this->client->loginUser($user);
 
-        $rentSystemFactory = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystemFactory = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         $rentSystemFactory->returnBike($user->getUserId(), self::BIKE_NUMBER, self::STAND_NAME, '', true);
         $rentSystemFactory->rentBike($user->getUserId(), self::BIKE_NUMBER);
         $rentSystemFactory->returnBike($user->getUserId(), self::BIKE_NUMBER, self::STAND_NAME);

--- a/tests/Application/Controller/Api/Bike/BikeRentTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeRentTest.php
@@ -7,6 +7,7 @@ namespace BikeShare\Test\Application\Controller\Api\Bike;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRentEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\UserRepository;
@@ -30,7 +31,7 @@ class BikeRentTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -44,7 +45,7 @@ class BikeRentTest extends BikeSharingWebTestCase
     {
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -83,7 +84,7 @@ class BikeRentTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . json_encode($response));
+        $this->assertFalse($response['error'], 'Response with error: ' . json_encode($response));
         $this->assertSame($response['code'], 'bike.rent.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('currentCode', $response['params'], 'Response params does not contain currentCode');

--- a/tests/Application/Controller/Api/Bike/BikeReturnTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeReturnTest.php
@@ -7,6 +7,7 @@ namespace BikeShare\Test\Application\Controller\Api\Bike;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeReturnEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -31,7 +32,7 @@ class BikeReturnTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -45,7 +46,7 @@ class BikeReturnTest extends BikeSharingWebTestCase
     {
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -70,7 +71,7 @@ class BikeReturnTest extends BikeSharingWebTestCase
         $response = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
         $this->assertArrayHasKey('message', $response, 'Response does not contain message key');
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . $response['message']);
+        $this->assertFalse($response['error'], 'Response with error: ' . $response['message']);
 
         $this->client->getContainer()->get('event_dispatcher')->addListener(
             BikeReturnEvent::class,
@@ -95,7 +96,7 @@ class BikeReturnTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . $response['message']);
+        $this->assertFalse($response['error'], 'Response with error: ' . $response['message']);
         $this->assertSame($response['code'], 'bike.return.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('standName', $response['params'], 'Response params does not contain standName');

--- a/tests/Application/Controller/Api/Bike/BikeRevertTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeRevertTest.php
@@ -7,6 +7,7 @@ namespace BikeShare\Test\Application\Controller\Api\Bike;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRevertEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -33,7 +34,7 @@ class BikeRevertTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -70,7 +71,7 @@ class BikeRevertTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . json_encode($response));
+        $this->assertFalse($response['error'], 'Response with error: ' . json_encode($response));
         $this->assertSame($response['code'], 'bike.rent.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('currentCode', $response['params'], 'Response params does not contain currentCode');
@@ -98,7 +99,7 @@ class BikeRevertTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . $response['message']);
+        $this->assertFalse($response['error'], 'Response with error: ' . $response['message']);
         $this->assertSame($response['code'], 'bike.revert.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('standName', $response['params'], 'Response params does not contain standName');

--- a/tests/Application/Controller/Api/Bike/BikeTripTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeTripTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\Api\Bike;
 
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +22,7 @@ class BikeTripTest extends BikeSharingWebTestCase
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
         $this->client->loginUser($user);
 
-        $rentSystemFactory = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystemFactory = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         $rentSystemFactory->rentBike($user->getUserId(), self::BIKE_NUMBER, true);
         $rentSystemFactory->returnBike($user->getUserId(), self::BIKE_NUMBER, self::STAND_NAME);
 

--- a/tests/Application/Controller/Api/Report/InactiveBikesReportTest.php
+++ b/tests/Application/Controller/Api/Report/InactiveBikesReportTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\Api\Report;
 
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
@@ -109,7 +110,7 @@ class InactiveBikesReportTest extends BikeSharingWebTestCase
 
     private function simulateBikeActivity(int $bikeNumber, string $standName, string $lastReturnTime): void
     {
-        $rentSystem = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystem = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         $returnTime = new \DateTimeImmutable($lastReturnTime);
 
         static::mockTime($returnTime->sub(new \DateInterval('PT2M'))->format('Y-m-d H:i:s'));
@@ -137,7 +138,7 @@ class InactiveBikesReportTest extends BikeSharingWebTestCase
     {
         static::mockTime('2000-01-01 00:00:00');
 
-        $rentSystem = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystem = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         foreach ([self::BIKE_INACTIVE_SHORT, self::BIKE_INACTIVE_LONG, self::BIKE_ON_SERVICE_STAND] as $bikeNumber) {
             $rentSystem->returnBike($this->adminUserId, $bikeNumber, self::SERVICE_STAND_NAME, '', true);
         }

--- a/tests/Application/Controller/Api/Report/InactiveBikesReportTest.php
+++ b/tests/Application/Controller/Api/Report/InactiveBikesReportTest.php
@@ -9,8 +9,6 @@ use BikeShare\Db\DbInterface;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
-use DateInterval;
-use DateTimeImmutable;
 use Symfony\Component\Clock\Test\ClockSensitiveTrait;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -112,12 +110,12 @@ class InactiveBikesReportTest extends BikeSharingWebTestCase
     private function simulateBikeActivity(int $bikeNumber, string $standName, string $lastReturnTime): void
     {
         $rentSystem = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
-        $returnTime = new DateTimeImmutable($lastReturnTime);
+        $returnTime = new \DateTimeImmutable($lastReturnTime);
 
-        static::mockTime($returnTime->sub(new DateInterval('PT2M'))->format('Y-m-d H:i:s'));
+        static::mockTime($returnTime->sub(new \DateInterval('PT2M'))->format('Y-m-d H:i:s'));
         $rentSystem->returnBike($this->adminUserId, $bikeNumber, $standName, '', true);
 
-        static::mockTime($returnTime->sub(new DateInterval('PT1M'))->format('Y-m-d H:i:s'));
+        static::mockTime($returnTime->sub(new \DateInterval('PT1M'))->format('Y-m-d H:i:s'));
         $rentSystem->rentBike($this->adminUserId, $bikeNumber, true);
 
         static::mockTime($returnTime->format('Y-m-d H:i:s'));

--- a/tests/Application/Controller/Api/Stand/StandBikeListTest.php
+++ b/tests/Application/Controller/Api/Stand/StandBikeListTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\Api\Stand;
 
+use BikeShare\Rent\Enum\RentSystemType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Rent\RentSystemFactory;
@@ -41,7 +42,7 @@ class StandBikeListTest extends BikeSharingWebTestCase
         #add bike to stand with note
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/Api/Stand/StandBikeListTest.php
+++ b/tests/Application/Controller/Api/Stand/StandBikeListTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\Api\Stand;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
@@ -30,9 +31,7 @@ class StandBikeListTest extends BikeSharingWebTestCase
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider bikeListOnStandDataProvider
-     */
+    #[DataProvider('bikeListOnStandDataProvider')]
     public function testBikeListOnStand(
         bool $forceStack,
         $expectedStackTopBike
@@ -69,7 +68,7 @@ class StandBikeListTest extends BikeSharingWebTestCase
         }
     }
 
-    public function bikeListOnStandDataProvider(): iterable
+    public static function bikeListOnStandDataProvider(): iterable
     {
         yield 'forceStack true' => [
             'forceStack' => true,

--- a/tests/Application/Controller/Api/User/UserBikeTest.php
+++ b/tests/Application/Controller/Api/User/UserBikeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Test\Application\Controller\Api\User;
 
 use BikeShare\App\Security\UserProvider;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
@@ -27,7 +28,7 @@ class UserBikeTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -41,7 +42,7 @@ class UserBikeTest extends BikeSharingWebTestCase
     {
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -72,7 +73,7 @@ class UserBikeTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . json_encode($response));
+        $this->assertFalse($response['error'], 'Response with error: ' . json_encode($response));
         $this->assertSame($response['code'], 'bike.rent.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('currentCode', $response['params'], 'Response params does not contain currentCode');

--- a/tests/Application/Controller/LanguageControllerTest.php
+++ b/tests/Application/Controller/LanguageControllerTest.php
@@ -13,14 +13,14 @@ class LanguageControllerTest extends BikeSharingWebTestCase
 {
     private const USER_PHONE_NUMBER = '421951111111';
 
-    public function setup(): void
+    protected function setup(): void
     {
         parent::setUp();
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::USER_PHONE_NUMBER);
         $this->client->getContainer()->get(UserSettingsRepository::class)->saveLocale($user->getUserId(), 'en');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::USER_PHONE_NUMBER);
         $this->client->getContainer()->get(UserSettingsRepository::class)->saveLocale($user->getUserId(), 'en');

--- a/tests/Application/Controller/LoginControllerTest.php
+++ b/tests/Application/Controller/LoginControllerTest.php
@@ -14,14 +14,14 @@ class LoginControllerTest extends BikeSharingWebTestCase
     private const USER_PHONE_NUMBER = '421951555555';
     private const USER_PHONE_PASSWORD = 'password';
 
-    public function setup(): void
+    protected function setup(): void
     {
         parent::setUp();
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::USER_PHONE_NUMBER);
         $this->client->getContainer()->get(UserSettingsRepository::class)->saveLocale($user->getUserId(), 'en');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::USER_PHONE_NUMBER);
         $this->client->getContainer()->get(UserSettingsRepository::class)->saveLocale($user->getUserId(), 'en');

--- a/tests/Application/Controller/ScanControllerTest.php
+++ b/tests/Application/Controller/ScanControllerTest.php
@@ -8,6 +8,7 @@ use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRentEvent;
 use BikeShare\Event\BikeReturnEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -32,7 +33,7 @@ class ScanControllerTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -46,7 +47,7 @@ class ScanControllerTest extends BikeSharingWebTestCase
     {
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/SmsRequestController/AddCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/AddCommandTest.php
@@ -92,7 +92,7 @@ class AddCommandTest extends BikeSharingWebTestCase
         $this->assertStringContainsString(
             'Hello ' . $firstName . PHP_EOL,
             $sentMessages[0]['message'],
-            'Email does not contain the user\'s first name'
+            "Email does not contain the user's first name"
         );
         # Assert that the email contains the link to the system rules page
         $this->assertStringContainsString(
@@ -116,6 +116,7 @@ class AddCommandTest extends BikeSharingWebTestCase
             if ($listener['pretty'] === 'BikeShare\EventListener\RegistrationEventListener::__invoke') {
                 $this->fail('Registration event listener was not called');
             }
+
             if ($listener['stub'] === 'closure(UserRegistrationEvent $event)') {
                 $this->fail('TestEventListener was not called');
             }

--- a/tests/Application/Controller/SmsRequestController/DelNoteCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/DelNoteCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Mail\MailSenderInterface;
 use BikeShare\Repository\NoteRepository;
@@ -38,9 +39,7 @@ class DelNoteCommandTest extends BikeSharingWebTestCase
         $noteRepository->addNoteToStand(self::STAND_ID, $user['userId'], 'Note for stand');
     }
 
-    /**
-     * @dataProvider standNotePatternDataProvider
-     */
+    #[DataProvider('standNotePatternDataProvider')]
     public function testDelNoteCommandForStand(
         ?string $pattern,
         string $expectedMessage,
@@ -99,8 +98,10 @@ class DelNoteCommandTest extends BikeSharingWebTestCase
                         'Invalid message sent to admin'
                     );
                 }
+
                 $notifiedNumbers[] = $sentMessage['number'];
             }
+
             $this->assertEqualsCanonicalizing(
                 array_merge([self::ADMIN_PHONE_NUMBER], array_column($admins, 'number')),
                 $notifiedNumbers,
@@ -133,7 +134,7 @@ class DelNoteCommandTest extends BikeSharingWebTestCase
         }
     }
 
-    public function standNotePatternDataProvider(): array
+    public static function standNotePatternDataProvider(): array
     {
         return [
             'No pattern' => [
@@ -164,9 +165,7 @@ class DelNoteCommandTest extends BikeSharingWebTestCase
         ];
     }
 
-    /**
-     * @dataProvider bikeNotePatternDataProvider
-     */
+    #[DataProvider('bikeNotePatternDataProvider')]
     public function testDelNoteCommandForBike(
         ?string $pattern,
         string $expectedMessage,
@@ -225,8 +224,10 @@ class DelNoteCommandTest extends BikeSharingWebTestCase
                         'Invalid message sent to admin'
                     );
                 }
+
                 $notifiedNumbers[] = $sentMessage['number'];
             }
+
             $this->assertEqualsCanonicalizing(
                 array_merge([self::ADMIN_PHONE_NUMBER], array_column($admins, 'number')),
                 $notifiedNumbers,
@@ -257,7 +258,7 @@ class DelNoteCommandTest extends BikeSharingWebTestCase
         }
     }
 
-    public function bikeNotePatternDataProvider(): array
+    public static function bikeNotePatternDataProvider(): array
     {
         return [
             'No pattern' => [

--- a/tests/Application/Controller/SmsRequestController/ForceRentCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/ForceRentCommandTest.php
@@ -83,6 +83,7 @@ class ForceRentCommandTest extends BikeSharingWebTestCase
             if ($listener['pretty'] === 'BikeShare\EventListener\TooManyBikeRentEventListener::__invoke') {
                 $this->fail('TooManyBikeRentEventListener was not called');
             }
+
             if ($listener['stub'] === 'closure(BikeRentEvent $event)') {
                 $this->fail('TestEventListener was not called');
             }

--- a/tests/Application/Controller/SmsRequestController/FreeCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/FreeCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
 use BikeShare\SmsConnector\SmsConnectorInterface;
@@ -14,9 +15,7 @@ class FreeCommandTest extends BikeSharingWebTestCase
 {
     private const USER_PHONE_NUMBER = '421951111111';
 
-    /**
-     * @dataProvider freeCommandDataProvider
-     */
+    #[DataProvider('freeCommandDataProvider')]
     public function testFreeCommand(
         array $findFreeBikesResult,
         array $findFreeStandsResult,
@@ -59,7 +58,7 @@ class FreeCommandTest extends BikeSharingWebTestCase
         $this->assertSame($expectedMessage, $sentMessage['text'], 'Invalid response sms text');
     }
 
-    public function freeCommandDataProvider(): iterable
+    public static function freeCommandDataProvider(): iterable
     {
         yield 'no free bikes' => [
             'findFreeBikesResult' => [],

--- a/tests/Application/Controller/SmsRequestController/HelpCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/HelpCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\SmsConnector\SmsConnectorInterface;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,9 +28,7 @@ class HelpCommandTest extends BikeSharingWebTestCase
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider smsHelpDataProvider
-     */
+    #[DataProvider('smsHelpDataProvider')]
     public function testHelpCommand(
         string $phoneNumber,
         array $expectedCommands,
@@ -61,6 +60,7 @@ class HelpCommandTest extends BikeSharingWebTestCase
                 'Response sms text does not contain expected command'
             );
         }
+
         foreach ($notExpectedCommands as $command) {
             $this->assertStringNotContainsString(
                 $command,
@@ -68,13 +68,14 @@ class HelpCommandTest extends BikeSharingWebTestCase
                 'Response sms text contains unexpected command'
             );
         }
+
         $this->assertStringContainsString($phoneNumber, $sentMessage['number'], 'Invalid response sms number');
     }
 
     /**
      * @phpcs:disable Generic.Files.LineLength
      */
-    public function smsHelpDataProvider(): iterable
+    public static function smsHelpDataProvider(): iterable
     {
         yield 'user help' => [
             'phoneNumber' => self::USER_PHONE_NUMBER,

--- a/tests/Application/Controller/SmsRequestController/ListCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/ListCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\SmsConnector\SmsConnectorInterface;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,9 +28,7 @@ class ListCommandTest extends BikeSharingWebTestCase
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider listCommandDataProvider
-     */
+    #[DataProvider('listCommandDataProvider')]
     public function testListCommand(
         bool $forceStack
     ): void {
@@ -87,7 +86,7 @@ class ListCommandTest extends BikeSharingWebTestCase
         }
     }
 
-    public function listCommandDataProvider(): iterable
+    public static function listCommandDataProvider(): iterable
     {
         yield 'force stack off' => [
             'forceStack' => false,

--- a/tests/Application/Controller/SmsRequestController/NoteCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/NoteCommandTest.php
@@ -76,8 +76,10 @@ class NoteCommandTest extends BikeSharingWebTestCase
                     'Invalid message sent to admin'
                 );
             }
+
             $notifiedNumbers[] = $sentMessage['number'];
         }
+
         $this->assertEqualsCanonicalizing(
             array_merge([self::USER_PHONE_NUMBER], array_column($admins, 'number')),
             $notifiedNumbers,
@@ -144,8 +146,10 @@ class NoteCommandTest extends BikeSharingWebTestCase
                     'Invalid message sent to admin'
                 );
             }
+
             $notifiedNumbers[] = $sentMessage['number'];
         }
+
         $this->assertEqualsCanonicalizing(
             array_merge([self::USER_PHONE_NUMBER], array_column($admins, 'number')),
             $notifiedNumbers,

--- a/tests/Application/Controller/SmsRequestController/RentCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/RentCommandTest.php
@@ -7,7 +7,6 @@ namespace BikeShare\Test\Application\Controller\SmsRequestController;
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRentEvent;
 use BikeShare\Rent\RentSystemFactory;
-use BikeShare\Rent\RentSystemInterface;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\UserRepository;
 use BikeShare\SmsConnector\SmsConnectorInterface;

--- a/tests/Application/Controller/SmsRequestController/RentCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/RentCommandTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRentEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\UserRepository;
@@ -30,7 +31,7 @@ class RentCommandTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -44,7 +45,7 @@ class RentCommandTest extends BikeSharingWebTestCase
     {
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/SmsRequestController/RentCommandWithCreditTest.php
+++ b/tests/Application/Controller/SmsRequestController/RentCommandWithCreditTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Credit\CreditSystemInterface;
 use BikeShare\Db\DbInterface;
 use BikeShare\Enum\CreditChangeType;
@@ -61,6 +62,7 @@ class RentCommandWithCreditTest extends BikeSharingWebTestCase
         if ($userCredit > 0) {
             $creditSystem->decreaseCredit($user['userId'], $userCredit, CreditChangeType::BALANCE_ADJUSTMENT);
         }
+
         $this->client->request(
             Request::METHOD_GET,
             '/receive.php',
@@ -77,9 +79,7 @@ class RentCommandWithCreditTest extends BikeSharingWebTestCase
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider rentCommandDataProvider
-     */
+    #[DataProvider('rentCommandDataProvider')]
     public function testRentCommand(
         bool $isCreditSystemEnabled,
         float $userCredit,

--- a/tests/Application/Controller/SmsRequestController/ReturnCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/ReturnCommandTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeReturnEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -33,7 +34,7 @@ class ReturnCommandTest extends BikeSharingWebTestCase
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
         #force return bike by admin
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -45,7 +46,7 @@ class ReturnCommandTest extends BikeSharingWebTestCase
         #rent bike by user
         $user = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->rentBike(
                 $user['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/SmsRequestController/ReturnCommandWithCreditTest.php
+++ b/tests/Application/Controller/SmsRequestController/ReturnCommandWithCreditTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Credit\CreditSystemInterface;
 use BikeShare\Db\DbInterface;
 use BikeShare\Enum\CreditChangeType;
@@ -44,6 +45,7 @@ class ReturnCommandWithCreditTest extends BikeSharingWebTestCase
         if ($userCredit > 0) {
             $creditSystem->decreaseCredit($user['userId'], $userCredit, CreditChangeType::BALANCE_ADJUSTMENT);
         }
+
         $this->client->request(
             Request::METHOD_GET,
             '/receive.php',
@@ -60,9 +62,7 @@ class ReturnCommandWithCreditTest extends BikeSharingWebTestCase
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider rentCommandDataProvider
-     */
+    #[DataProvider('rentCommandDataProvider')]
     public function testReturnCommand(
         float $userCredit,
         float $expectedCreditLeft,
@@ -163,11 +163,12 @@ class ReturnCommandWithCreditTest extends BikeSharingWebTestCase
                 $this->fail('TestEventListener was not called');
             }
         }
+
         $creditSystem = $this->client->getContainer()->get(CreditSystemInterface::class);
         $this->assertSame($expectedCreditLeft, $creditSystem->getUserCredit($user['userId']), 'Invalid credit left');
     }
 
-    public function rentCommandDataProvider(): iterable
+    public static function rentCommandDataProvider(): iterable
     {
         yield 'return without credit charge' => [
             'userCredit' => 100,

--- a/tests/Application/Controller/SmsRequestController/RevertCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/RevertCommandTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRevertEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -32,7 +33,7 @@ class RevertCommandTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/SmsRequestController/TagCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/TagCommandTest.php
@@ -75,8 +75,10 @@ class TagCommandTest extends BikeSharingWebTestCase
                     'Invalid message sent to admin'
                 );
             }
+
             $notifiedNumbers[] = $sentMessage['number'];
         }
+
         $this->assertEqualsCanonicalizing(
             array_merge([self::USER_PHONE_NUMBER], array_column($admins, 'number')),
             $notifiedNumbers,

--- a/tests/Application/Controller/SmsRequestController/UnTagCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/UnTagCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Mail\MailSenderInterface;
 use BikeShare\Repository\NoteRepository;
@@ -35,9 +36,7 @@ class UnTagCommandTest extends BikeSharingWebTestCase
         $noteRepository->addNoteToAllBikesOnStand(self::STAND_ID, $user['userId'], 'Note for bike');
     }
 
-    /**
-     * @dataProvider unTagPatternDataProvider
-     */
+    #[DataProvider('unTagPatternDataProvider')]
     public function testUnTagCommandForStand(
         ?string $pattern,
         string $expectedMessage,
@@ -96,8 +95,10 @@ class UnTagCommandTest extends BikeSharingWebTestCase
                         'Invalid message sent to admin'
                     );
                 }
+
                 $notifiedNumbers[] = $sentMessage['number'];
             }
+
             $this->assertEqualsCanonicalizing(
                 array_merge([self::ADMIN_PHONE_NUMBER], array_column($admins, 'number')),
                 $notifiedNumbers,
@@ -131,7 +132,7 @@ class UnTagCommandTest extends BikeSharingWebTestCase
         }
     }
 
-    public function unTagPatternDataProvider(): array
+    public static function unTagPatternDataProvider(): array
     {
         return [
             'No pattern' => [

--- a/tests/Application/Controller/SmsRequestController/WhereCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/WhereCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\SmsConnector\SmsConnectorInterface;
@@ -34,9 +35,7 @@ class WhereCommandTest extends BikeSharingWebTestCase
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider whereCommandDataProvider
-     */
+    #[DataProvider('whereCommandDataProvider')]
     public function testWhereCommand(
         string $startAction,
         string $expectedMessagePattern
@@ -77,7 +76,7 @@ class WhereCommandTest extends BikeSharingWebTestCase
         );
     }
 
-    public function whereCommandDataProvider(): iterable
+    public static function whereCommandDataProvider(): iterable
     {
         yield 'not rented bike' => [
             'startAction' => 'FORCERETURN ' . self::BIKE_NUMBER . ' ' . self::STAND_NAME,

--- a/tests/Application/Controller/SmsRequestController/WhereCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/WhereCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
+use BikeShare\Rent\Enum\RentSystemType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
@@ -24,7 +25,7 @@ class WhereCommandTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/SmsRequestControllerTest.php
+++ b/tests/Application/Controller/SmsRequestControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Repository\UserSettingsRepository;
@@ -21,8 +22,8 @@ class SmsRequestControllerTest extends BikeSharingWebTestCase
 
     /**
      * @var Callback|string $expectedSms
-     * @dataProvider smsDataProvider
      */
+    #[DataProvider('smsDataProvider')]
     public function testBaseSmsFlow(
         string $phoneNumber,
         string $message,
@@ -71,7 +72,7 @@ class SmsRequestControllerTest extends BikeSharingWebTestCase
         }
     }
 
-    public function smsDataProvider(): iterable
+    public static function smsDataProvider(): iterable
     {
         yield 'invalid phone number' => [
             'phoneNumber' => '0000000000000',
@@ -116,7 +117,7 @@ class SmsRequestControllerTest extends BikeSharingWebTestCase
             'message' => 'HELP',
             'expectedResponse' => '',
             'expectedResponseCode' => Response::HTTP_OK,
-            'expectedSms' => $this->callback(function ($message) {
+            'expectedSms' => new Callback(static function ($message) {
                 return (bool)preg_match('/Commands:.*/', $message);
             }),
             'expectedLog' => [],
@@ -126,7 +127,7 @@ class SmsRequestControllerTest extends BikeSharingWebTestCase
             'message' => 'WHERE 1',
             'expectedResponse' => '',
             'expectedResponseCode' => Response::HTTP_OK,
-            'expectedSms' => $this->callback(function ($message) {
+            'expectedSms' => new Callback(static function ($message) {
                 return (bool)preg_match('/Bike 1 is at stand STAND\d*. /', $message);
             }),
             'expectedLog' => [],

--- a/tests/Integration/BikeSharingKernelTestCase.php
+++ b/tests/Integration/BikeSharingKernelTestCase.php
@@ -87,14 +87,7 @@ abstract class BikeSharingKernelTestCase extends WebTestCase
                 // only care about ERROR and above
                 continue;
             }
-
-            $isExpected = false;
-            foreach ($this->expected as $expected) {
-                if ($matches($record, $expected)) {
-                    $isExpected = true;
-                    break;
-                }
-            }
+            $isExpected = array_any($this->expected, fn($expected) => $matches($record, $expected));
 
             if (!$isExpected) {
                 $unexpected[] = $record;

--- a/tests/Integration/Command/InactiveStandBikesCheckCommandTest.php
+++ b/tests/Integration/Command/InactiveStandBikesCheckCommandTest.php
@@ -9,8 +9,6 @@ use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\SmsConnector\SmsConnectorInterface;
 use BikeShare\Test\Integration\BikeSharingKernelTestCase;
-use DateInterval;
-use DateTimeImmutable;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Clock\Test\ClockSensitiveTrait;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -74,7 +72,7 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
             strpos($message, self::BIKE_INACTIVE_SHORT . ' | STAND1')
         );
 
-        $this->assertStringNotContainsString(self::BIKE_ON_SERVICE_STAND . ' |', $message);
+        $this->assertStringNotContainsString('- ' . self::BIKE_ON_SERVICE_STAND . ' |', $message);
 
         $smsConnector = self::getContainer()->get(SmsConnectorInterface::class);
         $this->assertCount(0, $smsConnector->getSentMessages(), 'SMS should not be sent to admins');
@@ -97,12 +95,12 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
     private function simulateBikeActivity(int $bikeNumber, string $standName, string $lastReturnTime): void
     {
         $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
-        $returnTime = new DateTimeImmutable($lastReturnTime);
+        $returnTime = new \DateTimeImmutable($lastReturnTime);
 
-        static::mockTime($returnTime->sub(new DateInterval('PT2M'))->format('Y-m-d H:i:s'));
+        static::mockTime($returnTime->sub(new \DateInterval('PT2M'))->format('Y-m-d H:i:s'));
         $rentSystem->returnBike($this->adminUserId, $bikeNumber, $standName, '', true);
 
-        static::mockTime($returnTime->sub(new DateInterval('PT1M'))->format('Y-m-d H:i:s'));
+        static::mockTime($returnTime->sub(new \DateInterval('PT1M'))->format('Y-m-d H:i:s'));
         $rentSystem->rentBike($this->adminUserId, $bikeNumber, true);
 
         static::mockTime($returnTime->format('Y-m-d H:i:s'));

--- a/tests/Integration/Command/InactiveStandBikesCheckCommandTest.php
+++ b/tests/Integration/Command/InactiveStandBikesCheckCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Test\Integration\Command;
 
 use BikeShare\Mail\MailSenderInterface;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\SmsConnector\SmsConnectorInterface;
@@ -94,7 +95,7 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
 
     private function simulateBikeActivity(int $bikeNumber, string $standName, string $lastReturnTime): void
     {
-        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         $returnTime = new \DateTimeImmutable($lastReturnTime);
 
         static::mockTime($returnTime->sub(new \DateInterval('PT2M'))->format('Y-m-d H:i:s'));
@@ -111,7 +112,7 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
     {
         static::mockTime('2000-01-01 00:00:00');
 
-        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         foreach ([self::BIKE_INACTIVE_SHORT, self::BIKE_INACTIVE_LONG, self::BIKE_ON_SERVICE_STAND] as $bikeNumber) {
             $rentSystem->returnBike($this->adminUserId, $bikeNumber, self::SERVICE_STAND_NAME, '', true);
         }

--- a/tests/Integration/Command/LongRentalCheckCommandTest.php
+++ b/tests/Integration/Command/LongRentalCheckCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Test\Integration\Command;
 
 use BikeShare\Mail\MailSenderInterface;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\SmsConnector\SmsConnectorInterface;
@@ -35,7 +36,7 @@ class LongRentalCheckCommandTest extends BikeSharingKernelTestCase
         $admin = self::getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -49,7 +50,7 @@ class LongRentalCheckCommandTest extends BikeSharingKernelTestCase
     {
         $admin = self::getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -71,7 +72,7 @@ class LongRentalCheckCommandTest extends BikeSharingKernelTestCase
 
         $user = self::getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
-        self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->rentBike($user['userId'], self::BIKE_NUMBER);
 
         static::mockTime('+' . $_ENV['WATCHES_LONG_RENTAL'] . ' hours 15 minutes');

--- a/tests/Integration/Command/MigrateCreditHistoryCommandTest.php
+++ b/tests/Integration/Command/MigrateCreditHistoryCommandTest.php
@@ -6,11 +6,11 @@ namespace BikeShare\Test\Integration\Command;
 
 use BikeShare\Enum\Action;
 use BikeShare\Enum\CreditChangeType;
+use BikeShare\Test\Integration\BikeSharingKernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class MigrateCreditHistoryCommandTest extends KernelTestCase
+class MigrateCreditHistoryCommandTest extends BikeSharingKernelTestCase
 {
     private CommandTester $commandTester;
     private $db;

--- a/tests/Integration/Command/PasswordHashStatsCommandTest.php
+++ b/tests/Integration/Command/PasswordHashStatsCommandTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace BikeShare\Test\Integration\Command;
 
 use BikeShare\Db\DbInterface;
+use BikeShare\Test\Integration\BikeSharingKernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class PasswordHashStatsCommandTest extends KernelTestCase
+class PasswordHashStatsCommandTest extends BikeSharingKernelTestCase
 {
     private CommandTester $commandTester;
     private DbInterface $db;

--- a/tests/Integration/EventListener/LongStandBonusEventListenerFunctionalTest.php
+++ b/tests/Integration/EventListener/LongStandBonusEventListenerFunctionalTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Integration\EventListener;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Credit\CreditSystemInterface;
 use BikeShare\Db\DbInterface;
 use BikeShare\Enum\Action;
@@ -52,9 +53,7 @@ class LongStandBonusEventListenerFunctionalTest extends BikeSharingKernelTestCas
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider bonusDataProvider
-     */
+    #[DataProvider('bonusDataProvider')]
     public function testLongStandBonusLogic(
         int $longStandDays,
         float $longStandBonus,
@@ -114,7 +113,7 @@ class LongStandBonusEventListenerFunctionalTest extends BikeSharingKernelTestCas
         );
     }
 
-    public function bonusDataProvider(): \Generator
+    public static function bonusDataProvider(): \Generator
     {
         yield 'bonus awarded: long stand, different stand' => [
             'longStandDays' => 7,

--- a/tests/Integration/EventListener/LongStandBonusEventListenerFunctionalTest.php
+++ b/tests/Integration/EventListener/LongStandBonusEventListenerFunctionalTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Integration\EventListener;
 
+use BikeShare\Rent\Enum\RentSystemType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Credit\CreditSystemInterface;
 use BikeShare\Db\DbInterface;
@@ -46,7 +47,7 @@ class LongStandBonusEventListenerFunctionalTest extends BikeSharingKernelTestCas
 
         $admin = self::getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike($admin['userId'], self::BIKE_NUMBER, self::STAND1_NAME, '', true);
 
         $_ENV = $this->originalEnv;
@@ -70,7 +71,7 @@ class LongStandBonusEventListenerFunctionalTest extends BikeSharingKernelTestCas
         $userRepository = self::getContainer()->get(UserRepository::class);
         $standRepository = self::getContainer()->get(StandRepository::class);
         $creditSystem = self::getContainer()->get(CreditSystemInterface::class);
-        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
 
         $user = $userRepository->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
         $admin = $userRepository->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);

--- a/tests/Integration/EventListener/TooManyBikeRentEventListenerTest.php
+++ b/tests/Integration/EventListener/TooManyBikeRentEventListenerTest.php
@@ -33,7 +33,7 @@ class TooManyBikeRentEventListenerTest extends BikeSharingKernelTestCase
             ->method('findRentCountByUser')
             ->with(
                 $user['userId'],
-                (new \DateTimeImmutable(self::CURRENT_TIME))
+                new \DateTimeImmutable(self::CURRENT_TIME)
                     ->sub(new \DateInterval('PT' . $_ENV['WATCHES_NUMBER_TOO_MANY'] . 'H'))
             )->willReturn(self::RENT_COUNT);
         $this->getContainer()->set(HistoryRepository::class, $historyRepository);

--- a/tests/Integration/Form/RegistrationFormTypeTest.php
+++ b/tests/Integration/Form/RegistrationFormTypeTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Integration\Form;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Form\RegistrationFormType;
 use BikeShare\Test\Integration\BikeSharingKernelTestCase;
 
 class RegistrationFormTypeTest extends BikeSharingKernelTestCase
 {
-    /**
-     * @dataProvider invalidDataProvider
-     */
+    #[DataProvider('invalidDataProvider')]
     public function testSubmitInvalidData(
         array $formData,
         array $expectedErrors = []
@@ -29,14 +28,16 @@ class RegistrationFormTypeTest extends BikeSharingKernelTestCase
             if (empty($key->getErrors())) {
                 continue;
             }
+
             foreach ($key->getErrors() as $error) {
                 $actualErrors[$key->getName()][] = $error->getMessage();
             }
         }
+
         $this->assertEquals($expectedErrors, $actualErrors);
     }
 
-    public function invalidDataProvider(): iterable
+    public static function invalidDataProvider(): iterable
     {
         $expectedErrors = [
             'fullname' => [
@@ -161,9 +162,7 @@ class RegistrationFormTypeTest extends BikeSharingKernelTestCase
         ];
     }
 
-    /**
-     * @dataProvider fullNamePurifyDataProvider
-     */
+    #[DataProvider('fullNamePurifyDataProvider')]
     public function testFullNamePurify(
         string $fullname,
         string $expectedFullname
@@ -183,7 +182,7 @@ class RegistrationFormTypeTest extends BikeSharingKernelTestCase
         $this->assertSame($expectedFullname, $form->get('fullname')->getData());
     }
 
-    public function fullNamePurifyDataProvider(): iterable
+    public static function fullNamePurifyDataProvider(): iterable
     {
         yield 'default' => [
             'fullname' => 'Test User',
@@ -195,7 +194,7 @@ class RegistrationFormTypeTest extends BikeSharingKernelTestCase
         ];
         yield 'xss code in name' => [
             'fullname' => '<script>alert(Test);</script> User',
-            'expectedfullname' => 'alert(Test); User',
+            'expectedFullname' => 'alert(Test); User',
         ];
     }
 }

--- a/tests/Integration/Security/RoutesAccessTest.php
+++ b/tests/Integration/Security/RoutesAccessTest.php
@@ -60,6 +60,7 @@ class RoutesAccessTest extends BikeSharingKernelTestCase
             if (empty($methods)) {
                 $methods = [Request::METHOD_GET];
             }
+
             foreach ($methods as $method) {
                 $request = Request::create($route, $method);
                 [$attributes, $channel] = $accessMap->getPatterns($request);

--- a/tests/Unit/Command/InactiveStandBikesCheckCommandTest.php
+++ b/tests/Unit/Command/InactiveStandBikesCheckCommandTest.php
@@ -16,12 +16,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class InactiveStandBikesCheckCommandTest extends TestCase
 {
-    /** @var BikeRepository|MockObject */
-    private $bikeRepository;
-    /** @var AdminNotifier|MockObject */
-    private $adminNotifier;
-    /** @var ClockInterface|MockObject */
-    private $clock;
+    private BikeRepository&MockObject $bikeRepository;
+    private AdminNotifier&MockObject $adminNotifier;
+    private ClockInterface&MockObject $clock;
     private CommandTester $commandTester;
 
     protected function setUp(): void
@@ -87,7 +84,7 @@ class InactiveStandBikesCheckCommandTest extends TestCase
         $this->adminNotifier
             ->expects($this->once())
             ->method('notify')
-            ->with($this->isType('string'), false)
+            ->with($this->isString(), false)
             ->willReturnCallback(
                 static function (string $message, bool $bySms) use (&$notifiedMessage): void {
                     $notifiedMessage = $message;

--- a/tests/Unit/Command/PasswordHashStatsCommandTest.php
+++ b/tests/Unit/Command/PasswordHashStatsCommandTest.php
@@ -14,16 +14,12 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class PasswordHashStatsCommandTest extends TestCase
 {
-    /** @var DbInterface|MockObject */
-    private $db;
-    /** @var DbResultInterface|MockObject */
-    private $dbResult;
+    private DbInterface&MockObject $db;
     private CommandTester $commandTester;
 
     protected function setUp(): void
     {
         $this->db = $this->createMock(DbInterface::class);
-        $this->dbResult = $this->createMock(DbResultInterface::class);
 
         $command = new PasswordHashStatsCommand($this->db);
         $this->commandTester = new CommandTester($command);
@@ -31,8 +27,9 @@ class PasswordHashStatsCommandTest extends TestCase
 
     public function testExecuteReturnsFailureWhenStatsQueryFails(): void
     {
-        $this->db->expects($this->once())->method('query')->willReturn($this->dbResult);
-        $this->dbResult->expects($this->once())->method('fetchAssoc')->willReturn(false);
+        $dbResult = $this->createMock(DbResultInterface::class);
+        $this->db->expects($this->once())->method('query')->willReturn($dbResult);
+        $dbResult->expects($this->once())->method('fetchAssoc')->willReturn(false);
 
         $this->commandTester->execute([]);
         $this->assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
@@ -55,8 +52,9 @@ class PasswordHashStatsCommandTest extends TestCase
 
     public function testExecuteReturnsSuccessWithWarningForEmptyStats(): void
     {
-        $this->db->expects($this->once())->method('query')->willReturn($this->dbResult);
-        $this->dbResult->expects($this->once())->method('fetchAssoc')->willReturn([]);
+        $dbResult = $this->createMock(DbResultInterface::class);
+        $this->db->expects($this->once())->method('query')->willReturn($dbResult);
+        $dbResult->expects($this->once())->method('fetchAssoc')->willReturn([]);
 
         $this->commandTester->execute([]);
         $this->assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());

--- a/tests/Unit/Credit/CreditSystemFactoryTest.php
+++ b/tests/Unit/Credit/CreditSystemFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\Credit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Credit\CreditSystem;
 use BikeShare\Credit\CreditSystemFactory;
 use BikeShare\Credit\DisabledCreditSystem;
@@ -12,9 +13,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class CreditSystemFactoryTest extends TestCase
 {
-    /**
-     * @dataProvider creditSystemDataProvider
-     */
+    #[DataProvider('creditSystemDataProvider')]
     public function testGetCreditSystem(
         $isCreditSystemEnabled,
         $expectedSystemClass
@@ -28,7 +27,7 @@ class CreditSystemFactoryTest extends TestCase
         $serviceLocatorMock->expects($this->once())
             ->method('get')
             ->with($expectedSystemClass)
-            ->willReturn($this->createMock($expectedSystemClass));
+            ->willReturn($this->createStub($expectedSystemClass));
 
         $this->assertInstanceOf(
             $expectedSystemClass,
@@ -36,7 +35,7 @@ class CreditSystemFactoryTest extends TestCase
         );
     }
 
-    public function creditSystemDataProvider()
+    public static function creditSystemDataProvider()
     {
         yield 'disabled credit system' => [
             'isCreditSystemEnabled' => false,

--- a/tests/Unit/Credit/CreditSystemTest.php
+++ b/tests/Unit/Credit/CreditSystemTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\Credit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Credit\CreditSystem;
 use BikeShare\Db\DbInterface;
 use BikeShare\Db\DbResultInterface;
@@ -12,9 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class CreditSystemTest extends TestCase
 {
-    /**
-     * @dataProvider constructorDataProvider
-     */
+    #[DataProvider('constructorDataProvider')]
     public function testConstructor(
         $isEnabled,
         $creditCurrency,
@@ -30,6 +29,7 @@ class CreditSystemTest extends TestCase
         if (!is_null($expectedException)) {
             $this->expectException($expectedException);
         }
+
         $creditSystem = new CreditSystem(
             $isEnabled,
             $creditCurrency,
@@ -39,8 +39,8 @@ class CreditSystemTest extends TestCase
             $longRentalFee,
             $limitIncreaseFee,
             $violationFee,
-            $this->createMock(DbInterface::class),
-            $this->createMock(HistoryRepository::class)
+            $this->createStub(DbInterface::class),
+            $this->createStub(HistoryRepository::class)
         );
         $this->assertEquals($isEnabled, $creditSystem->isEnabled());
         $this->assertEquals($creditCurrency, $creditSystem->getCreditCurrency());
@@ -52,7 +52,7 @@ class CreditSystemTest extends TestCase
         $this->assertEquals($violationFee, $creditSystem->getViolationFee());
     }
 
-    public function constructorDataProvider()
+    public static function constructorDataProvider()
     {
         $default = [
             'isEnabled' => true,
@@ -144,7 +144,7 @@ class CreditSystemTest extends TestCase
             10, //limitIncreaseFee
             5, //violationFee
             $db,
-            $this->createMock(HistoryRepository::class)
+            $this->createStub(HistoryRepository::class)
         );
 
         $this->assertEquals(5, $creditSystem->getUserCredit($userId));
@@ -175,7 +175,7 @@ class CreditSystemTest extends TestCase
             10, //limitIncreaseFee
             5, //violationFee
             $db,
-            $this->createMock(HistoryRepository::class)
+            $this->createStub(HistoryRepository::class)
         );
 
         $this->assertEquals(0, $creditSystem->getUserCredit($userId));

--- a/tests/Unit/EventListener/LongStandBonusEventListenerTest.php
+++ b/tests/Unit/EventListener/LongStandBonusEventListenerTest.php
@@ -10,6 +10,7 @@ use BikeShare\EventListener\LongStandBonusEventListener;
 use BikeShare\Repository\HistoryRepository;
 use BikeShare\Repository\StandRepository;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\ClockInterface;
 
@@ -24,14 +25,14 @@ class LongStandBonusEventListenerTest extends TestCase
     private const LONG_STAND_BONUS = 5.0;
     private const CURRENT_TIME = '2023-10-15 12:00:00';
 
-    private ClockInterface&MockObject $clock;
+    private ClockInterface&Stub $clock;
     private HistoryRepository&MockObject $historyRepository;
     private StandRepository&MockObject $standRepository;
     private CreditSystemInterface&MockObject $creditSystem;
 
     protected function setUp(): void
     {
-        $this->clock = $this->createMock(ClockInterface::class);
+        $this->clock = $this->createStub(ClockInterface::class);
         $this->clock->method('now')->willReturn(new \DateTimeImmutable(self::CURRENT_TIME));
 
         $this->historyRepository = $this->createMock(HistoryRepository::class);
@@ -43,6 +44,7 @@ class LongStandBonusEventListenerTest extends TestCase
     {
         $listener = $this->createListener(longStandDays: 0);
 
+        $this->standRepository->expects($this->never())->method('findItemByName');
         $this->historyRepository->expects($this->never())->method('findPreviousBikeReturn');
         $this->creditSystem->expects($this->never())->method('increaseCredit');
 
@@ -53,6 +55,7 @@ class LongStandBonusEventListenerTest extends TestCase
     {
         $listener = $this->createListener();
 
+        $this->standRepository->expects($this->never())->method('findItemByName');
         $this->historyRepository
             ->expects($this->once())
             ->method('findPreviousBikeReturn')

--- a/tests/Unit/Mail/PHPMailerSenderTest.php
+++ b/tests/Unit/Mail/PHPMailerSenderTest.php
@@ -11,14 +11,8 @@ use PHPUnit\Framework\TestCase;
 
 class PHPMailerSenderTest extends TestCase
 {
-    /**
-     * @var PHPMailer|MockObject
-     */
-    private $mailer;
-    /**
-     * @var PHPMailerMailSender
-     */
-    private $mailSender;
+    private PHPMailer&MockObject $mailer;
+    private PHPMailerMailSender $mailSender;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Purifier/PhonePurifierTest.php
+++ b/tests/Unit/Purifier/PhonePurifierTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\Purifier;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Purifier\PhonePurifier;
 use libphonenumber\PhoneNumberUtil;
 use PHPUnit\Framework\TestCase;
 
 class PhonePurifierTest extends TestCase
 {
-    /**
-     * @dataProvider purifyDataProvider
-     */
+    #[DataProvider('purifyDataProvider')]
     public function testPurify(
         $phoneNumber,
         $countryCode,
@@ -22,11 +21,12 @@ class PhonePurifierTest extends TestCase
         if ($expectedException) {
             $this->expectException($expectedException);
         }
+
         $purifier = new PhonePurifier(PhoneNumberUtil::getInstance(), [$countryCode]);
         $this->assertEquals($expectedPhoneNumber, $purifier->purify($phoneNumber));
     }
 
-    public function purifyDataProvider()
+    public static function purifyDataProvider()
     {
         yield 'default' => [
             'phoneNumber' => '+421 903-123-456',

--- a/tests/Unit/Sms/SmsSenderTest.php
+++ b/tests/Unit/Sms/SmsSenderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\Sms;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Sms\SmsSender;
 use BikeShare\SmsConnector\SmsConnectorInterface;
@@ -46,9 +47,7 @@ class SmsSenderTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider sendDataProvider
-     */
+    #[DataProvider('sendDataProvider')]
     public function testSend(
         $number,
         $message,
@@ -68,7 +67,7 @@ class SmsSenderTest extends TestCase
             ->expects($matcher)
             ->method('send')
             ->willReturnCallback(function (...$parameters) use ($matcher, $smsConnectorCallParams) {
-                $this->assertSame($smsConnectorCallParams[$matcher->getInvocationCount() - 1], $parameters);
+                $this->assertSame($smsConnectorCallParams[$matcher->numberOfInvocations() - 1], $parameters);
             });
         $this->smsConnectorMock
             ->expects($this->once())
@@ -79,13 +78,13 @@ class SmsSenderTest extends TestCase
             ->expects($matcher)
             ->method('query')
             ->willReturnCallback(function (...$parameters) use ($matcher, $dbCallParams) {
-                $this->assertSame($dbCallParams[$matcher->getInvocationCount() - 1], $parameters);
+                $this->assertSame($dbCallParams[$matcher->numberOfInvocations() - 1], $parameters);
             });
 
         $this->smsSender->send($number, $message);
     }
 
-    public function sendDataProvider()
+    public static function sendDataProvider()
     {
         yield 'short message' => [
             'number' => '123456789',

--- a/tests/Unit/SmsCommand/AddCommandTest.php
+++ b/tests/Unit/SmsCommand/AddCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\SmsCommand;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\App\Entity\User;
 use BikeShare\Purifier\PhonePurifierInterface;
 use BikeShare\Repository\UserRepository;
@@ -17,15 +18,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AddCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var UserRegistration|MockObject */
-    private $userRegistrationMock;
-    /** @var UserRepository|MockObject */
-    private $userRepositoryMock;
-    /** @var PhonePurifierInterface|MockObject */
-    private $phonePurifierMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private UserRegistration&MockObject $userRegistrationMock;
+    private UserRepository&MockObject $userRepositoryMock;
+    private PhonePurifierInterface&MockObject $phonePurifierMock;
     private AddCommand $command;
 
     protected function setUp(): void
@@ -54,7 +50,7 @@ class AddCommandTest extends TestCase
         );
     }
 
-    /** @dataProvider invokeThrowsValidationDataProvider */
+    #[DataProvider('invokeThrowsValidationDataProvider')]
     public function testInvokeThrowsValidation(
         string $phonePurifierCallResult,
         bool $isValid,
@@ -68,6 +64,8 @@ class AddCommandTest extends TestCase
         $userMock = $this->createMock(User::class);
         $phone = '123456789';
 
+        $userMock->expects($this->never())->method('getCity');
+        $this->userRegistrationMock->expects($this->never())->method('register');
         $this->phonePurifierMock
             ->expects($this->once())
             ->method('isValid')
@@ -108,7 +106,7 @@ class AddCommandTest extends TestCase
         $purifiedPhone = '421123456789';
         $city = 'Bratislava';
         $fullName = 'Test User';
-        $newUser = $this->createMock(User::class);
+        $newUser = $this->createStub(User::class);
         $message = 'User Test User added. They need to read email and agree to rules before using the system.';
 
         $userMock->expects($this->once())->method('getCity')->willReturn($city);
@@ -143,6 +141,9 @@ class AddCommandTest extends TestCase
     {
         $message = 'with email, phone, fullname: ADD king@earth.com 0901456789 Martin Luther King Jr.';
 
+        $this->userRegistrationMock->expects($this->never())->method('register');
+        $this->userRepositoryMock->expects($this->never())->method('findItemByPhoneNumber');
+        $this->phonePurifierMock->expects($this->never())->method('isValid');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')
@@ -155,7 +156,7 @@ class AddCommandTest extends TestCase
         $this->assertEquals($message, $this->command->getHelpMessage());
     }
 
-    public function invokeThrowsValidationDataProvider(): Generator
+    public static function invokeThrowsValidationDataProvider(): Generator
     {
         yield 'phone number invalid' => [
             'phonePurifierCallResult' => '420123456789',

--- a/tests/Unit/SmsCommand/CommandDetectorTest.php
+++ b/tests/Unit/SmsCommand/CommandDetectorTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\SmsCommand;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\SmsCommand\CommandDetector;
 use PHPUnit\Framework\TestCase;
 
 class CommandDetectorTest extends TestCase
 {
-    /**
-     * @dataProvider detectDataProvider
-     */
+    #[DataProvider('detectDataProvider')]
     public function testDetect(string $command, array $expected)
     {
         $detector = new CommandDetector();
@@ -21,7 +20,7 @@ class CommandDetectorTest extends TestCase
     /**
      * @phpcs:disable Generic.Files.LineLength
      */
-    public function detectDataProvider(): iterable
+    public static function detectDataProvider(): iterable
     {
         yield 'HELP' => [
             'command' => 'HELP',

--- a/tests/Unit/SmsCommand/CreditCommandTest.php
+++ b/tests/Unit/SmsCommand/CreditCommandTest.php
@@ -14,11 +14,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CreditCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var CreditSystemInterface|MockObject */
-    private $creditSystemMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private CreditSystemInterface&MockObject $creditSystemMock;
     private CreditCommand $command;
 
     protected function setUp(): void
@@ -55,7 +52,7 @@ class CreditCommandTest extends TestCase
 
     public function testInvokeThrowsWhenCreditDisabled(): void
     {
-        $userMock = $this->createMock(User::class);
+        $userMock = $this->createStub(User::class);
         $expectedMessage = 'Error. The command CREDIT does not exist. If you need help, send: HELP';
 
         $this->creditSystemMock->expects($this->once())->method('isEnabled')->willReturn(false);
@@ -77,6 +74,8 @@ class CreditCommandTest extends TestCase
 
     public function testGetHelpMessage(): void
     {
+        $this->translatorMock->expects($this->never())->method('trans');
+        $this->creditSystemMock->expects($this->never())->method('isEnabled');
         $this->assertSame('', $this->command->getHelpMessage());
     }
 }

--- a/tests/Unit/SmsCommand/ForceRentCommandTest.php
+++ b/tests/Unit/SmsCommand/ForceRentCommandTest.php
@@ -13,11 +13,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ForceRentCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var RentSystemInterface|MockObject */
-    private $rentSystemMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private RentSystemInterface&MockObject $rentSystemMock;
     private ForceRentCommand $command;
 
     protected function setUp(): void
@@ -39,6 +36,7 @@ class ForceRentCommandTest extends TestCase
         $bikeNumber = 456;
         $expectedMessage = 'Rent successful';
 
+        $this->translatorMock->expects($this->never())->method('trans');
         $userMock->expects($this->once())->method('getUserId')->willReturn($userId);
         $this->rentSystemMock
             ->expects($this->once())
@@ -52,6 +50,7 @@ class ForceRentCommandTest extends TestCase
     public function testGetHelpMessage(): void
     {
         $expectedMessage = 'Translated help message';
+        $this->rentSystemMock->expects($this->never())->method('rentBike');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')

--- a/tests/Unit/SmsCommand/ForceRentCommandTest.php
+++ b/tests/Unit/SmsCommand/ForceRentCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\SmsCommand;
 
 use BikeShare\App\Entity\User;
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemInterface;
 use BikeShare\SmsCommand\ForceRentCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,7 +44,7 @@ class ForceRentCommandTest extends TestCase
             ->expects($this->once())
             ->method('rentBike')
             ->with($userId, $bikeNumber, true)
-            ->willReturn(['message' => $expectedMessage]);
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.rent.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber));
     }

--- a/tests/Unit/SmsCommand/ForceReturnCommandTest.php
+++ b/tests/Unit/SmsCommand/ForceReturnCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\SmsCommand;
 
 use BikeShare\App\Entity\User;
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemInterface;
 use BikeShare\SmsCommand\ForceReturnCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -44,7 +46,7 @@ class ForceReturnCommandTest extends TestCase
             ->expects($this->once())
             ->method('returnBike')
             ->with($userId, $bikeNumber, $standName, $note, true)
-            ->willReturn(['message' => $expectedMessage]);
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber, $standName, $note));
     }
@@ -62,8 +64,8 @@ class ForceReturnCommandTest extends TestCase
         $this->rentSystemMock
             ->expects($this->once())
             ->method('returnBike')
-            ->with($userId, $bikeNumber, $standName, '', true)
-            ->willReturn(['message' => $expectedMessage]);
+            ->with($userId, $bikeNumber, $standName, null, true)
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber, $standName));
     }

--- a/tests/Unit/SmsCommand/ForceReturnCommandTest.php
+++ b/tests/Unit/SmsCommand/ForceReturnCommandTest.php
@@ -13,11 +13,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ForceReturnCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var RentSystemInterface|MockObject */
-    private $rentSystemMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private RentSystemInterface&MockObject $rentSystemMock;
     private ForceReturnCommand $command;
 
     protected function setUp(): void
@@ -41,6 +38,7 @@ class ForceReturnCommandTest extends TestCase
         $note = 'note';
         $expectedMessage = 'Return successful';
 
+        $this->translatorMock->expects($this->never())->method('trans');
         $userMock->expects($this->once())->method('getUserId')->willReturn($userId);
         $this->rentSystemMock
             ->expects($this->once())
@@ -59,6 +57,7 @@ class ForceReturnCommandTest extends TestCase
         $standName = 'CENTRALPARK';
         $expectedMessage = 'Returned without note';
 
+        $this->translatorMock->expects($this->never())->method('trans');
         $userMock->expects($this->once())->method('getUserId')->willReturn($userId);
         $this->rentSystemMock
             ->expects($this->once())
@@ -72,6 +71,7 @@ class ForceReturnCommandTest extends TestCase
     public function testGetHelpMessage(): void
     {
         $expectedMessage = 'Translated help text';
+        $this->rentSystemMock->expects($this->never())->method('returnBike');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')

--- a/tests/Unit/SmsCommand/FreeCommandTest.php
+++ b/tests/Unit/SmsCommand/FreeCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\SmsCommand;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\App\Entity\User;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -15,13 +16,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FreeCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var BikeRepository|MockObject */
-    private $bikeRepositoryMock;
-    /** @var StandRepository|MockObject */
-    private $standRepositoryMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private BikeRepository&MockObject $bikeRepositoryMock;
+    private StandRepository&MockObject $standRepositoryMock;
     private FreeCommand $command;
 
     protected function setUp(): void
@@ -37,7 +34,7 @@ class FreeCommandTest extends TestCase
         unset($this->translatorMock, $this->bikeRepositoryMock, $this->standRepositoryMock, $this->command);
     }
 
-    /** @dataProvider invokeDataProvider */
+    #[DataProvider('invokeDataProvider')]
     public function testInvoke(
         array $bikeRepositoryCallResult,
         array $translatorCallParams,
@@ -46,7 +43,7 @@ class FreeCommandTest extends TestCase
         array $standRepositoryCallResult,
         string $message
     ): void {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
 
         $this->bikeRepositoryMock
             ->expects($this->once())
@@ -58,9 +55,9 @@ class FreeCommandTest extends TestCase
             ->method('trans')
             ->willReturnCallback(
                 function (...$parameters) use ($matcher, $translatorCallParams, $translatorCallResult) {
-                    $this->assertEquals($translatorCallParams[$matcher->getInvocationCount() - 1], $parameters);
+                    $this->assertEquals($translatorCallParams[$matcher->numberOfInvocations() - 1], $parameters);
 
-                    return $translatorCallResult[$matcher->getInvocationCount() - 1];
+                    return $translatorCallResult[$matcher->numberOfInvocations() - 1];
                 }
             );
         $this->standRepositoryMock
@@ -73,10 +70,13 @@ class FreeCommandTest extends TestCase
 
     public function testGetHelpMessage(): void
     {
+        $this->translatorMock->expects($this->never())->method('trans');
+        $this->bikeRepositoryMock->expects($this->never())->method('findFreeBikes');
+        $this->standRepositoryMock->expects($this->never())->method('findFreeStands');
         $this->assertSame('', $this->command->getHelpMessage());
     }
 
-    public function invokeDataProvider(): Generator
+    public static function invokeDataProvider(): Generator
     {
         yield 'empty free bikes' => [
             'bikeRepositoryCallResult' => [],

--- a/tests/Unit/SmsCommand/HelpCommandTest.php
+++ b/tests/Unit/SmsCommand/HelpCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\SmsCommand;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\App\Entity\User;
 use BikeShare\Credit\CreditSystemInterface;
 use BikeShare\SmsCommand\HelpCommand;
@@ -14,11 +15,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class HelpCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var CreditSystemInterface|MockObject */
-    private $creditSystemMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private CreditSystemInterface&MockObject $creditSystemMock;
     private HelpCommand $command;
 
     protected function setUp(): void
@@ -33,18 +31,19 @@ class HelpCommandTest extends TestCase
         unset($this->translatorMock, $this->creditSystemMock, $this->command);
     }
 
-    /** @dataProvider invokeDataProvider */
+    #[DataProvider('invokeDataProvider')]
     public function testInvoke(bool $creditSystemCallResult, int $userCallResult, string $message): void
     {
         $userMock = $this->createMock(User::class);
 
+        $this->translatorMock->expects($this->never())->method('trans');
         $this->creditSystemMock->expects($this->once())->method('isEnabled')->willReturn($creditSystemCallResult);
         $userMock->expects($this->once())->method('getPrivileges')->willReturn($userCallResult);
 
         $this->assertSame($message, ($this->command)($userMock));
     }
 
-    public function invokeDataProvider(): Generator
+    public static function invokeDataProvider(): Generator
     {
         yield 'credit system disabled user privileges zero' => [
             'creditSystemCallResult' => false,
@@ -108,6 +107,8 @@ class HelpCommandTest extends TestCase
 
     public function testGetHelpMessage(): void
     {
+        $this->translatorMock->expects($this->never())->method('trans');
+        $this->creditSystemMock->expects($this->never())->method('isEnabled');
         $this->assertSame('', $this->command->getHelpMessage());
     }
 }

--- a/tests/Unit/SmsCommand/InfoCommandTest.php
+++ b/tests/Unit/SmsCommand/InfoCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\SmsCommand;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\App\Entity\User;
 use BikeShare\Repository\StandRepository;
 use BikeShare\SmsCommand\Exception\ValidationException;
@@ -15,11 +16,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class InfoCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var StandRepository|MockObject */
-    private $standRepositoryMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private StandRepository&MockObject $standRepositoryMock;
     private InfoCommand $command;
 
     protected function setUp(): void
@@ -34,12 +32,13 @@ class InfoCommandTest extends TestCase
         unset($this->translatorMock, $this->standRepositoryMock, $this->command);
     }
 
-    /** @dataProvider invokeDataProvider */
+    #[DataProvider('invokeDataProvider')]
     public function testInvoke(float $standLong, float $standLat, string $standPhoto, string $message): void
     {
-        $userMock = $this->createMock(User::class);
+        $userMock = $this->createStub(User::class);
         $standName = 'STAND42';
 
+        $this->translatorMock->expects($this->never())->method('trans');
         $this->standRepositoryMock
             ->expects($this->once())
             ->method('findItemByName')
@@ -56,10 +55,11 @@ class InfoCommandTest extends TestCase
 
     public function testInvokeThrowsWhenInvalidStandName(): void
     {
-        $userMock = $this->createMock(User::class);
+        $userMock = $this->createStub(User::class);
         $standName = '123_invalid';
         $expectedMessage = 'Stand name 123_invalid has not been recognized.';
 
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')
@@ -77,7 +77,7 @@ class InfoCommandTest extends TestCase
 
     public function testInvokeThrowsWhenEmptyStandInfo(): void
     {
-        $userMock = $this->createMock(User::class);
+        $userMock = $this->createStub(User::class);
         $standName = 'STAND404';
 
         $this->standRepositoryMock
@@ -98,7 +98,7 @@ class InfoCommandTest extends TestCase
         ($this->command)($userMock, $standName);
     }
 
-    public function invokeDataProvider(): Generator
+    public static function invokeDataProvider(): Generator
     {
         yield 'standLong not empty' => [
             'standLong' => 1.1,
@@ -146,6 +146,7 @@ class InfoCommandTest extends TestCase
 
     public function testGetHelpMessage(): void
     {
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')

--- a/tests/Unit/SmsCommand/LastCommandTest.php
+++ b/tests/Unit/SmsCommand/LastCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\SmsCommand;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\App\Entity\User;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\SmsCommand\Exception\ValidationException;
@@ -15,11 +16,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class LastCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var BikeRepository|MockObject */
-    private $bikeRepositoryMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private BikeRepository&MockObject $bikeRepositoryMock;
     private LastCommand $command;
 
     protected function setUp(): void
@@ -34,14 +32,13 @@ class LastCommandTest extends TestCase
         unset($this->translatorMock, $this->bikeRepositoryMock, $this->command);
     }
 
-    /**
-     * @dataProvider invokeDataProvider
-     */
+    #[DataProvider('invokeDataProvider')]
     public function testInvoke(array $bikeRepositoryCallResult, string $message): void
     {
         $bikeNumber = 123;
-        $userMock = $this->createMock(User::class);
+        $userMock = $this->createStub(User::class);
 
+        $this->translatorMock->expects($this->never())->method('trans');
         $this->bikeRepositoryMock
             ->expects($this->once())
             ->method('findItem')
@@ -61,7 +58,7 @@ class LastCommandTest extends TestCase
     {
         $bikeNumber = 123;
         $errorMessage = 'Bike 123 does not exist.';
-        $userMock = $this->createMock(User::class);
+        $userMock = $this->createStub(User::class);
 
         $this->bikeRepositoryMock->expects($this->once())->method('findItem')->with($bikeNumber)->willReturn([]);
         $this->translatorMock
@@ -80,6 +77,7 @@ class LastCommandTest extends TestCase
     {
         $message = 'with bike number: LAST 42';
 
+        $this->bikeRepositoryMock->expects($this->never())->method('findItem');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')
@@ -89,7 +87,7 @@ class LastCommandTest extends TestCase
         $this->assertEquals($message, $this->command->getHelpMessage());
     }
 
-    public function invokeDataProvider(): Generator
+    public static function invokeDataProvider(): Generator
     {
         yield 'empty history' => [
             'bikeRepositoryCallResult' => [],

--- a/tests/Unit/SmsCommand/NoteCommandTest.php
+++ b/tests/Unit/SmsCommand/NoteCommandTest.php
@@ -16,15 +16,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class NoteCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var BikeRepository|MockObject */
-    private $bikeRepositoryMock;
-    /** @var StandRepository|MockObject */
-    private $standRepositoryMock;
-    /** @var NoteRepository|MockObject */
-    private $noteRepositoryMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private BikeRepository&MockObject $bikeRepositoryMock;
+    private StandRepository&MockObject $standRepositoryMock;
+    private NoteRepository&MockObject $noteRepositoryMock;
     private NoteCommand $command;
 
     protected function setUp(): void
@@ -55,11 +50,12 @@ class NoteCommandTest extends TestCase
 
     public function testAddBikeNoteSuccess(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $user->method('getUserId')->willReturn(1);
         $bikeNumber = 42;
         $note = 'Flat tire';
 
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
         $this->bikeRepositoryMock
             ->expects($this->once())
             ->method('findItem')
@@ -77,9 +73,12 @@ class NoteCommandTest extends TestCase
 
     public function testAddBikeNoteEmptyNoteThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $bikeNumber = 42;
 
+        $this->bikeRepositoryMock->expects($this->never())->method('findItem');
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToBike');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')
@@ -96,9 +95,11 @@ class NoteCommandTest extends TestCase
 
     public function testAddBikeNoteBikeNotFoundThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $bikeNumber = 99;
 
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToBike');
         $this->bikeRepositoryMock->expects($this->once())->method('findItem')->with($bikeNumber)->willReturn([]);
         $this->translatorMock
             ->expects($this->once())
@@ -113,11 +114,12 @@ class NoteCommandTest extends TestCase
 
     public function testAddStandNoteSuccess(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $user->method('getUserId')->willReturn(2);
         $stand = 'STAND1';
         $note = 'No bikes available';
 
+        $this->bikeRepositoryMock->expects($this->never())->method('findItem');
         $this->standRepositoryMock
             ->expects($this->once())
             ->method('findItemByName')
@@ -141,9 +143,12 @@ class NoteCommandTest extends TestCase
 
     public function testAddStandNoteEmptyNoteThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $stand = 'STAND1';
 
+        $this->bikeRepositoryMock->expects($this->never())->method('findItem');
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToStand');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')
@@ -160,9 +165,12 @@ class NoteCommandTest extends TestCase
 
     public function testAddStandNoteInvalidStandNameThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $stand = 'stand#1';
 
+        $this->bikeRepositoryMock->expects($this->never())->method('findItem');
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToStand');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')
@@ -180,9 +188,11 @@ class NoteCommandTest extends TestCase
 
     public function testAddStandNoteStandNotFoundThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $stand = 'STAND2';
 
+        $this->bikeRepositoryMock->expects($this->never())->method('findItem');
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToStand');
         $this->standRepositoryMock->expects($this->once())->method('findItemByName')->with($stand)->willReturn(null);
         $this->translatorMock
             ->expects($this->once())
@@ -197,17 +207,21 @@ class NoteCommandTest extends TestCase
 
     public function testInvokeWithNoBikeOrStandThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $matcher = $this->exactly(2);
 
+        $this->bikeRepositoryMock->expects($this->never())->method('findItem');
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToBike');
         $this->translatorMock
             ->expects($matcher)
             ->method('trans')->willReturnCallback(function (...$parameters) use ($matcher) {
-                if ($matcher->getInvocationCount() === 1) {
+                if ($matcher->numberOfInvocations() === 1) {
                     $this->assertSame('Flat tire on front wheel', $parameters[0]);
                     return 'Flat tire on front wheel';
                 }
-                if ($matcher->getInvocationCount() === 2) {
+
+                if ($matcher->numberOfInvocations() === 2) {
                     $this->assertSame('with bike number/stand name and problem description: {example}', $parameters[0]);
                     return 'Help message';
                 }
@@ -221,14 +235,18 @@ class NoteCommandTest extends TestCase
     public function testGetHelpMessage(): void
     {
         $matcher = $this->exactly(2);
+        $this->bikeRepositoryMock->expects($this->never())->method('findItem');
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToBike');
         $this->translatorMock
             ->expects($matcher)
             ->method('trans')->willReturnCallback(function (...$parameters) use ($matcher) {
-                if ($matcher->getInvocationCount() === 1) {
+                if ($matcher->numberOfInvocations() === 1) {
                     $this->assertSame('Flat tire on front wheel', $parameters[0]);
                     return 'Flat tire on front wheel';
                 }
-                if ($matcher->getInvocationCount() === 2) {
+
+                if ($matcher->numberOfInvocations() === 2) {
                     $this->assertSame('with bike number/stand name and problem description: {example}', $parameters[0]);
                     $this->assertSame(['example' => 'NOTE 42 Flat tire on front wheel'], $parameters[1]);
                     return 'with bike number/stand name and problem description: NOTE 42 Flat tire on front wheel';

--- a/tests/Unit/SmsCommand/RentCommandTest.php
+++ b/tests/Unit/SmsCommand/RentCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\SmsCommand;
 
 use BikeShare\App\Entity\User;
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemInterface;
 use BikeShare\SmsCommand\RentCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,7 +44,7 @@ class RentCommandTest extends TestCase
             ->expects($this->once())
             ->method('rentBike')
             ->with($userId, $bikeNumber)
-            ->willReturn(['message' => $expectedMessage]);
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.rent.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber));
     }

--- a/tests/Unit/SmsCommand/RentCommandTest.php
+++ b/tests/Unit/SmsCommand/RentCommandTest.php
@@ -13,11 +13,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class RentCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var RentSystemInterface|MockObject */
-    private $rentSystemMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private RentSystemInterface&MockObject $rentSystemMock;
     private RentCommand $command;
 
     protected function setUp(): void
@@ -39,6 +36,7 @@ class RentCommandTest extends TestCase
         $bikeNumber = 456;
         $expectedMessage = 'Bike rented successfully.';
 
+        $this->translatorMock->expects($this->never())->method('trans');
         $userMock->expects($this->once())->method('getUserId')->willReturn($userId);
         $this->rentSystemMock
             ->expects($this->once())
@@ -52,6 +50,7 @@ class RentCommandTest extends TestCase
     public function testGetHelpMessage(): void
     {
         $expectedMessage = 'with bike number: RENT 42';
+        $this->rentSystemMock->expects($this->never())->method('rentBike');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')

--- a/tests/Unit/SmsCommand/ReturnCommandTest.php
+++ b/tests/Unit/SmsCommand/ReturnCommandTest.php
@@ -13,11 +13,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ReturnCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var RentSystemInterface|MockObject */
-    private $rentSystemMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private RentSystemInterface&MockObject $rentSystemMock;
     private ReturnCommand $command;
 
     protected function setUp(): void
@@ -41,6 +38,7 @@ class ReturnCommandTest extends TestCase
         $note = 'no issues';
         $expectedMessage = 'Bike rented successfully.';
 
+        $this->translatorMock->expects($this->never())->method('trans');
         $userMock->expects($this->once())->method('getUserId')->willReturn($userId);
         $this->rentSystemMock
             ->expects($this->once())
@@ -54,6 +52,7 @@ class ReturnCommandTest extends TestCase
     public function testGetHelpMessage(): void
     {
         $expectedMessage = 'with bike number: RETURN 42 MAINSQUARE note';
+        $this->rentSystemMock->expects($this->never())->method('returnBike');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')

--- a/tests/Unit/SmsCommand/ReturnCommandTest.php
+++ b/tests/Unit/SmsCommand/ReturnCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\SmsCommand;
 
 use BikeShare\App\Entity\User;
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemInterface;
 use BikeShare\SmsCommand\ReturnCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -44,7 +46,7 @@ class ReturnCommandTest extends TestCase
             ->expects($this->once())
             ->method('returnBike')
             ->with($userId, $bikeNumber, $standName, $note)
-            ->willReturn(['message' => $expectedMessage]);
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber, $standName, $note));
     }

--- a/tests/Unit/SmsCommand/RevertCommandTest.php
+++ b/tests/Unit/SmsCommand/RevertCommandTest.php
@@ -13,11 +13,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class RevertCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var RentSystemInterface|MockObject */
-    private $rentSystemMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private RentSystemInterface&MockObject $rentSystemMock;
     private RevertCommand $command;
 
     protected function setUp(): void
@@ -39,6 +36,7 @@ class RevertCommandTest extends TestCase
         $bikeNumber = 456;
         $expectedMessage = 'Bike 42 reverted.';
 
+        $this->translatorMock->expects($this->never())->method('trans');
         $userMock->expects($this->once())->method('getUserId')->willReturn($userId);
         $this->rentSystemMock
             ->expects($this->once())
@@ -52,6 +50,7 @@ class RevertCommandTest extends TestCase
     public function testGetHelpMessage(): void
     {
         $expectedMessage = 'Bike rented successfully.';
+        $this->rentSystemMock->expects($this->never())->method('revertBike');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')

--- a/tests/Unit/SmsCommand/RevertCommandTest.php
+++ b/tests/Unit/SmsCommand/RevertCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\SmsCommand;
 
 use BikeShare\App\Entity\User;
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemInterface;
 use BikeShare\SmsCommand\RevertCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,7 +44,7 @@ class RevertCommandTest extends TestCase
             ->expects($this->once())
             ->method('revertBike')
             ->with($userId, $bikeNumber)
-            ->willReturn(['message' => $expectedMessage]);
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.revert.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber));
     }

--- a/tests/Unit/SmsCommand/TagCommandTest.php
+++ b/tests/Unit/SmsCommand/TagCommandTest.php
@@ -15,13 +15,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class TagCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var StandRepository|MockObject */
-    private $standRepositoryMock;
-    /** @var NoteRepository|MockObject */
-    private $noteRepositoryMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private StandRepository&MockObject $standRepositoryMock;
+    private NoteRepository&MockObject $noteRepositoryMock;
     private TagCommand $command;
 
     protected function setUp(): void
@@ -45,7 +41,7 @@ class TagCommandTest extends TestCase
 
     public function testTagStandSuccess(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $user->method('getUserId')->willReturn(10);
         $standName = 'MAINSTAND';
         $note = 'vandalism';
@@ -73,11 +69,13 @@ class TagCommandTest extends TestCase
 
     public function testTagStandEmptyNoteThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $standName = 'MAINSTAND';
         $message = 'Empty tag for stand {standName} not saved, '
             . 'for deleting notes for all bikes on stand use UNTAG (for admins).';
 
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToAllBikesOnStand');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')
@@ -91,9 +89,11 @@ class TagCommandTest extends TestCase
 
     public function testTagStandInvalidStandNameThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $standName = 'stand#1';
 
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToAllBikesOnStand');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')
@@ -110,9 +110,10 @@ class TagCommandTest extends TestCase
 
     public function testTagStandNotFoundThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $standName = 'UNKNOWNSTAND';
 
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToAllBikesOnStand');
         $this->standRepositoryMock
             ->expects($this->once())
             ->method('findItemByName')
@@ -131,14 +132,17 @@ class TagCommandTest extends TestCase
     public function testGetHelpMessage(): void
     {
         $matcher = $this->exactly(2);
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('addNoteToAllBikesOnStand');
         $this->translatorMock
             ->expects($matcher)
             ->method('trans')->willReturnCallback(function (...$parameters) use ($matcher) {
-                if ($matcher->getInvocationCount() === 1) {
+                if ($matcher->numberOfInvocations() === 1) {
                     $this->assertSame('vandalism', $parameters[0]);
                     return 'vandalism';
                 }
-                if ($matcher->getInvocationCount() === 2) {
+
+                if ($matcher->numberOfInvocations() === 2) {
                     $this->assertSame('with stand name and problem description: {example}', $parameters[0]);
                     $this->assertSame(['example' => 'TAG MAINSQUARE vandalism'], $parameters[1]);
                     return 'with stand name and problem description: TAG MAINSQUARE vandalism';

--- a/tests/Unit/SmsCommand/UnTagCommandTest.php
+++ b/tests/Unit/SmsCommand/UnTagCommandTest.php
@@ -15,13 +15,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class UnTagCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var StandRepository|MockObject */
-    private $standRepositoryMock;
-    /** @var NoteRepository|MockObject */
-    private $noteRepositoryMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private StandRepository&MockObject $standRepositoryMock;
+    private NoteRepository&MockObject $noteRepositoryMock;
     private UnTagCommand $command;
 
     protected function setUp(): void
@@ -49,7 +45,7 @@ class UnTagCommandTest extends TestCase
 
     public function testUnTagStandSuccessNoPattern(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $stand = 'MAINSQUARE';
 
         $this->standRepositoryMock
@@ -79,7 +75,7 @@ class UnTagCommandTest extends TestCase
 
     public function testUnTagStandSuccessWithPattern(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $stand = 'MAINSQUARE';
         $pattern = 'vandalism';
 
@@ -110,9 +106,11 @@ class UnTagCommandTest extends TestCase
 
     public function testUnTagStandInvalidStandNameThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $stand = 'stand#1';
 
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('deleteNotesForAllBikesOnStand');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')
@@ -129,9 +127,10 @@ class UnTagCommandTest extends TestCase
 
     public function testUnTagStandNotFoundThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $stand = 'UNKNOWNSTAND';
 
+        $this->noteRepositoryMock->expects($this->never())->method('deleteNotesForAllBikesOnStand');
         $this->standRepositoryMock->expects($this->once())->method('findItemByName')->with($stand)->willReturn(null);
         $this->translatorMock
             ->expects($this->once())
@@ -146,7 +145,7 @@ class UnTagCommandTest extends TestCase
 
     public function testUnTagStandNoNotesFoundThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $stand = 'MAINSQUARE';
 
         $this->standRepositoryMock
@@ -175,7 +174,7 @@ class UnTagCommandTest extends TestCase
 
     public function testUnTagStandNoNotesFoundWithPatternThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $stand = 'MAINSQUARE';
         $pattern = 'vandalism';
 
@@ -208,16 +207,19 @@ class UnTagCommandTest extends TestCase
     public function testGetHelpMessage(): void
     {
         $matcher = $this->exactly(2);
+        $this->standRepositoryMock->expects($this->never())->method('findItemByName');
+        $this->noteRepositoryMock->expects($this->never())->method('deleteNotesForAllBikesOnStand');
         $this->translatorMock->expects($matcher)
             ->method('trans')
             ->willReturnCallback(
                 function (...$parameters) use ($matcher) {
-                    if ($matcher->getInvocationCount() === 1) {
+                    if ($matcher->numberOfInvocations() === 1) {
                         $this->assertSame('vandalism', $parameters[0]);
 
                         return 'vandalism';
                     }
-                    if ($matcher->getInvocationCount() === 2) {
+
+                    if ($matcher->numberOfInvocations() === 2) {
                         $this->assertSame(
                             'with stand name and optional pattern. '
                                 . 'All notes matching pattern will be deleted for all bikes on that stand: {example}',

--- a/tests/Unit/SmsCommand/WhereCommandTest.php
+++ b/tests/Unit/SmsCommand/WhereCommandTest.php
@@ -15,13 +15,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class WhereCommandTest extends TestCase
 {
-    /** @var TranslatorInterface|MockObject */
-    private $translatorMock;
-    /** @var BikeRepository|MockObject */
-    private $bikeRepositoryMock;
-    /** @var NoteRepository|MockObject */
-    private $noteRepositoryMock;
-
+    private TranslatorInterface&MockObject $translatorMock;
+    private BikeRepository&MockObject $bikeRepositoryMock;
+    private NoteRepository&MockObject $noteRepositoryMock;
     private WhereCommand $command;
 
     protected function setUp(): void
@@ -49,7 +45,7 @@ class WhereCommandTest extends TestCase
 
     public function testBikeAtStand(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $bikeNumber = 42;
 
         $this->bikeRepositoryMock
@@ -85,7 +81,7 @@ class WhereCommandTest extends TestCase
 
     public function testBikeRented(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $bikeNumber = 42;
 
         $this->bikeRepositoryMock
@@ -125,9 +121,10 @@ class WhereCommandTest extends TestCase
 
     public function testBikeNotFoundThrows(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $bikeNumber = 42;
 
+        $this->noteRepositoryMock->expects($this->never())->method('findBikeNote');
         $this->bikeRepositoryMock
             ->expects($this->once())
             ->method('findItem')
@@ -146,6 +143,8 @@ class WhereCommandTest extends TestCase
 
     public function testGetHelpMessage(): void
     {
+        $this->bikeRepositoryMock->expects($this->never())->method('findItem');
+        $this->noteRepositoryMock->expects($this->never())->method('findBikeNote');
         $this->translatorMock
             ->expects($this->once())
             ->method('trans')

--- a/tests/Unit/SmsConnector/DebugConnectorTest.php
+++ b/tests/Unit/SmsConnector/DebugConnectorTest.php
@@ -14,7 +14,7 @@ class DebugConnectorTest extends TestCase
     public function testSend()
     {
         $loggerMock = $this->createMock(LoggerInterface::class);
-        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack = $this->createStub(RequestStack::class);
         $debugConnector = new DebugConnector(
             $requestStack,
             $loggerMock,

--- a/tests/Unit/SmsConnector/EuroSmsConnectorTest.php
+++ b/tests/Unit/SmsConnector/EuroSmsConnectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\SmsConnector;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\SmsConnector\EuroSmsConnector;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
@@ -11,7 +12,6 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class EuroSmsConnectorTest extends TestCase
 {
@@ -30,8 +30,8 @@ class EuroSmsConnectorTest extends TestCase
             ]
         ];
 
-        $requestStack = $this->createMock(RequestStack::class);
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $requestStack = $this->createStub(RequestStack::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
         $smsConnector = new EuroSmsConnector(
             $requestStack,
             $httpClient,
@@ -40,20 +40,15 @@ class EuroSmsConnectorTest extends TestCase
 
         $reflection = new \ReflectionClass($smsConnector);
         $gatewayId = $reflection->getProperty('gatewayId');
-        $gatewayId->setAccessible(true);
         $gatewayKey = $reflection->getProperty('gatewayKey');
-        $gatewayKey->setAccessible(true);
         $gatewaySenderNumber = $reflection->getProperty('gatewaySenderNumber');
-        $gatewaySenderNumber->setAccessible(true);
 
         $this->assertEquals('Id', $gatewayId->getValue($smsConnector));
         $this->assertEquals('Key', $gatewayKey->getValue($smsConnector));
         $this->assertEquals('SenderNumber', $gatewaySenderNumber->getValue($smsConnector));
     }
 
-    /**
-     * @dataProvider checkConfigErrorDataProvider
-     */
+    #[DataProvider('checkConfigErrorDataProvider')]
     public function testCheckConfigError(
         ?string $gatewayId,
         ?string $gatewayKey,
@@ -67,8 +62,8 @@ class EuroSmsConnectorTest extends TestCase
                 'gatewaySenderNumber' => $gatewaySenderNumber,
             ]
         ];
-        $requestStack = $this->createMock(RequestStack::class);
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $requestStack = $this->createStub(RequestStack::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
         new EuroSmsConnector(
             $requestStack,
             $httpClient,
@@ -77,7 +72,7 @@ class EuroSmsConnectorTest extends TestCase
     }
 
 
-    public function checkConfigErrorDataProvider(): \Generator
+    public static function checkConfigErrorDataProvider(): \Generator
     {
         yield 'gatewayId is empty' => [
             '',
@@ -105,8 +100,8 @@ class EuroSmsConnectorTest extends TestCase
                 'gatewaySenderNumber' => 'SenderNumber',
             ]
         ];
-        $requestStack = $this->createMock(RequestStack::class);
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $requestStack = $this->createStub(RequestStack::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
         $smsConnector = new EuroSmsConnector(
             $requestStack,
             $httpClient,
@@ -115,7 +110,6 @@ class EuroSmsConnectorTest extends TestCase
 
         $reflection = new \ReflectionClass($smsConnector);
         $uuid = $reflection->getProperty('uuid');
-        $uuid->setAccessible(true);
         $uuid->setValue($smsConnector, 'uuid');
 
         $this->expectOutputString('ok:uuid' . "\n");
@@ -135,7 +129,7 @@ class EuroSmsConnectorTest extends TestCase
         $mockResponse = new MockResponse('', ['http_code' => 200]);
         $httpClient = new MockHttpClient($mockResponse);
 
-        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack = $this->createStub(RequestStack::class);
         $smsConnector = new EuroSmsConnector(
             $requestStack,
             $httpClient,
@@ -148,7 +142,6 @@ class EuroSmsConnectorTest extends TestCase
         // Create a spy for the calculateSignature method
         $reflection = new \ReflectionClass($smsConnector);
         $calculateSignature = $reflection->getMethod('calculateSignature');
-        $calculateSignature->setAccessible(true);
         $expectedSignature = $calculateSignature->invoke($smsConnector, $phoneNumber, $message);
 
         $smsConnector->send($phoneNumber, $message);
@@ -186,8 +179,8 @@ class EuroSmsConnectorTest extends TestCase
             ]
         ];
 
-        $requestStack = $this->createMock(RequestStack::class);
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $requestStack = $this->createStub(RequestStack::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
         $smsConnector = new EuroSmsConnector(
             $requestStack,
             $httpClient,
@@ -196,7 +189,6 @@ class EuroSmsConnectorTest extends TestCase
 
         $reflection = new \ReflectionClass($smsConnector);
         $calculateSignature = $reflection->getMethod('calculateSignature');
-        $calculateSignature->setAccessible(true);
 
         $number = '123456789';
         $text = 'Hello World';

--- a/tests/Unit/SmsConnector/SmsConnectorFactoryTest.php
+++ b/tests/Unit/SmsConnector/SmsConnectorFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Unit\SmsConnector;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\SmsConnector\DisabledConnector;
 use BikeShare\SmsConnector\EuroSmsConnector;
 use BikeShare\SmsConnector\SmsConnectorFactory;
@@ -19,15 +20,17 @@ class SmsConnectorFactoryTest extends TestCase
      * @param bool $debugMode
      * @param string $expectedInstance
      * @param string|null $expectedException
-     * @dataProvider getConnectorDataProvider
      */
+    #[DataProvider('getConnectorDataProvider')]
     public function testGetConnector(
         $connectorName,
         $debugMode,
         $expectedInstance,
         $expectedExceptionMessage = null
     ) {
-        $logger = $this->createMock(LoggerInterface::class);
+        $logger = $expectedExceptionMessage
+            ? $this->createMock(LoggerInterface::class)
+            : $this->createStub(LoggerInterface::class);
         $serviceLocatorMock = $this->createMock(ServiceLocator::class);
 
         if ($expectedExceptionMessage) {
@@ -41,7 +44,7 @@ class SmsConnectorFactoryTest extends TestCase
                 ->expects($this->once())
                 ->method('get')
                 ->with($connectorName)
-                ->willReturn($this->createMock($expectedInstance));
+                ->willReturn($this->createStub($expectedInstance));
         }
 
         $smsConnectorFactory = new SmsConnectorFactory($connectorName, $serviceLocatorMock, $logger);
@@ -57,11 +60,12 @@ class SmsConnectorFactoryTest extends TestCase
                         && $context['exception']->getMessage() === $expectedExceptionMessage)
                 );
         }
+
         $result = $smsConnectorFactory->getConnector();
         $this->assertInstanceOf($expectedInstance, $result);
     }
 
-    public function getConnectorDataProvider()
+    public static function getConnectorDataProvider()
     {
         yield 'eurosms' => [
             'connectorName' => 'eurosms',

--- a/tests/Unit/SmsTextNormalizer/AsciiSmsTextNormalizerTest.php
+++ b/tests/Unit/SmsTextNormalizer/AsciiSmsTextNormalizerTest.php
@@ -43,6 +43,7 @@ class AsciiSmsTextNormalizerTest extends TestCase
     public function testSetLocaleChangesLocale(): void
     {
         $newLocale = 'uk';
+        $this->translitMock->expects($this->never())->method('convert');
         $this->normalizer->setLocale($newLocale);
 
         $this->assertSame($newLocale, $this->normalizer->getLocale());
@@ -50,6 +51,7 @@ class AsciiSmsTextNormalizerTest extends TestCase
 
     public function testGetLocaleReturnsCurrentLocale(): void
     {
+        $this->translitMock->expects($this->never())->method('convert');
         $this->assertSame($this->defaultLocale, $this->normalizer->getLocale());
     }
 


### PR DESCRIPTION
## Summary
- move `RentSystemResult` to `src/Rent/DTO`
- add `RentSystemType` enum and replace string system type usage across RentSystem
- update RentSystem factory/interface/contracts to use enum and DTO
- update controllers, DI config, and tests to use enum-based `getRentSystem(...)`

## Validation
- `php bin/console cache:clear` (APP_ENV=test)
- `php bin/console load:fixtures`
- `vendor/bin/phpunit --configuration phpunit.xml`

All tests passed: 299 tests, 2314 assertions.